### PR TITLE
Add APIs to retrieve dirty page states

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 24.1,
+  "coverage_score": 22.60,
   "exclude_path": "",
   "crate_features": "with-serde,fam-wrappers"
 }

--- a/mshv-bindings/src/bindings.rs
+++ b/mshv-bindings/src/bindings.rs
@@ -9807,403 +9807,6 @@ impl Default for hv_port_id {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct hv_port_info {
-    pub port_type: hv_port_type,
-    pub padding: __u32,
-    pub __bindgen_anon_1: hv_port_info__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union hv_port_info__bindgen_ty_1 {
-    pub message_port_info: hv_port_info__bindgen_ty_1__bindgen_ty_1,
-    pub event_port_info: hv_port_info__bindgen_ty_1__bindgen_ty_2,
-    pub monitor_port_info: hv_port_info__bindgen_ty_1__bindgen_ty_3,
-    pub doorbell_port_info: hv_port_info__bindgen_ty_1__bindgen_ty_4,
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_port_info__bindgen_ty_1__bindgen_ty_1 {
-    pub target_sint: __u32,
-    pub target_vp: __u32,
-    pub rsvdz: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_port_info__bindgen_ty_1__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_port_info__bindgen_ty_1__bindgen_ty_1>(),
-        16usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_1)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_port_info__bindgen_ty_1__bindgen_ty_1>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_1>())).target_sint
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(target_sint)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_1>())).target_vp
-                as *const _ as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(target_vp)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_1>())).rsvdz as *const _
-                as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(rsvdz)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_port_info__bindgen_ty_1__bindgen_ty_2 {
-    pub target_sint: __u32,
-    pub target_vp: __u32,
-    pub base_flag_number: __u16,
-    pub flag_count: __u16,
-    pub rsvdz: __u32,
-}
-#[test]
-fn bindgen_test_layout_hv_port_info__bindgen_ty_1__bindgen_ty_2() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_port_info__bindgen_ty_1__bindgen_ty_2>(),
-        16usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_port_info__bindgen_ty_1__bindgen_ty_2>(),
-        4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_2>())).target_sint
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(target_sint)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_2>())).target_vp
-                as *const _ as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(target_vp)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_2>())).base_flag_number
-                as *const _ as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(base_flag_number)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_2>())).flag_count
-                as *const _ as usize
-        },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(flag_count)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_2>())).rsvdz as *const _
-                as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(rsvdz)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_port_info__bindgen_ty_1__bindgen_ty_3 {
-    pub monitor_address: __u64,
-    pub rsvdz: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_port_info__bindgen_ty_1__bindgen_ty_3() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_port_info__bindgen_ty_1__bindgen_ty_3>(),
-        16usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_3)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_port_info__bindgen_ty_1__bindgen_ty_3>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_3>())).monitor_address
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_3),
-            "::",
-            stringify!(monitor_address)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_3>())).rsvdz as *const _
-                as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_3),
-            "::",
-            stringify!(rsvdz)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_port_info__bindgen_ty_1__bindgen_ty_4 {
-    pub target_sint: __u32,
-    pub target_vp: __u32,
-    pub rsvdz: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_port_info__bindgen_ty_1__bindgen_ty_4() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_port_info__bindgen_ty_1__bindgen_ty_4>(),
-        16usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_4)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_port_info__bindgen_ty_1__bindgen_ty_4>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_4>())).target_sint
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_4),
-            "::",
-            stringify!(target_sint)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_4>())).target_vp
-                as *const _ as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_4),
-            "::",
-            stringify!(target_vp)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1__bindgen_ty_4>())).rsvdz as *const _
-                as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1__bindgen_ty_4),
-            "::",
-            stringify!(rsvdz)
-        )
-    );
-}
-#[test]
-fn bindgen_test_layout_hv_port_info__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_port_info__bindgen_ty_1>(),
-        16usize,
-        concat!("Size of: ", stringify!(hv_port_info__bindgen_ty_1))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_port_info__bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(hv_port_info__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1>())).message_port_info as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1),
-            "::",
-            stringify!(message_port_info)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1>())).event_port_info as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1),
-            "::",
-            stringify!(event_port_info)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1>())).monitor_port_info as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1),
-            "::",
-            stringify!(monitor_port_info)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_port_info__bindgen_ty_1>())).doorbell_port_info as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info__bindgen_ty_1),
-            "::",
-            stringify!(doorbell_port_info)
-        )
-    );
-}
-impl Default for hv_port_info__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[test]
-fn bindgen_test_layout_hv_port_info() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_port_info>(),
-        24usize,
-        concat!("Size of: ", stringify!(hv_port_info))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_port_info>(),
-        8usize,
-        concat!("Alignment of ", stringify!(hv_port_info))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<hv_port_info>())).port_type as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info),
-            "::",
-            stringify!(port_type)
-        )
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<hv_port_info>())).padding as *const _ as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_port_info),
-            "::",
-            stringify!(padding)
-        )
-    );
-}
-impl Default for hv_port_info {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
 pub union hv_connection_id {
     pub asu32: __u32,
     pub u: hv_connection_id__bindgen_ty_1,
@@ -10299,308 +9902,6 @@ fn bindgen_test_layout_hv_connection_id() {
     );
 }
 impl Default for hv_connection_id {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct hv_connection_info {
-    pub port_type: hv_port_type,
-    pub padding: __u32,
-    pub __bindgen_anon_1: hv_connection_info__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union hv_connection_info__bindgen_ty_1 {
-    pub message_connection_info: hv_connection_info__bindgen_ty_1__bindgen_ty_1,
-    pub event_connection_info: hv_connection_info__bindgen_ty_1__bindgen_ty_2,
-    pub monitor_connection_info: hv_connection_info__bindgen_ty_1__bindgen_ty_3,
-    pub doorbell_connection_info: hv_connection_info__bindgen_ty_1__bindgen_ty_4,
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_connection_info__bindgen_ty_1__bindgen_ty_1 {
-    pub rsvdz: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_connection_info__bindgen_ty_1__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_1>(),
-        8usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_1)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_1>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1__bindgen_ty_1>())).rsvdz
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(rsvdz)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_connection_info__bindgen_ty_1__bindgen_ty_2 {
-    pub rsvdz: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_connection_info__bindgen_ty_1__bindgen_ty_2() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_2>(),
-        8usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_2)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_2>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1__bindgen_ty_2>())).rsvdz
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(rsvdz)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_connection_info__bindgen_ty_1__bindgen_ty_3 {
-    pub monitor_address: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_connection_info__bindgen_ty_1__bindgen_ty_3() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_3>(),
-        8usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_3)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_3>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1__bindgen_ty_3>()))
-                .monitor_address as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_3),
-            "::",
-            stringify!(monitor_address)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Default, Copy, Clone)]
-pub struct hv_connection_info__bindgen_ty_1__bindgen_ty_4 {
-    pub gpa: __u64,
-    pub trigger_value: __u64,
-    pub flags: __u64,
-}
-#[test]
-fn bindgen_test_layout_hv_connection_info__bindgen_ty_1__bindgen_ty_4() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_4>(),
-        24usize,
-        concat!(
-            "Size of: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_4)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_connection_info__bindgen_ty_1__bindgen_ty_4>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1__bindgen_ty_4>())).gpa
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_4),
-            "::",
-            stringify!(gpa)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1__bindgen_ty_4>())).trigger_value
-                as *const _ as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_4),
-            "::",
-            stringify!(trigger_value)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1__bindgen_ty_4>())).flags
-                as *const _ as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1__bindgen_ty_4),
-            "::",
-            stringify!(flags)
-        )
-    );
-}
-#[test]
-fn bindgen_test_layout_hv_connection_info__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_connection_info__bindgen_ty_1>(),
-        24usize,
-        concat!("Size of: ", stringify!(hv_connection_info__bindgen_ty_1))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_connection_info__bindgen_ty_1>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(hv_connection_info__bindgen_ty_1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1>())).message_connection_info
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1),
-            "::",
-            stringify!(message_connection_info)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1>())).event_connection_info
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1),
-            "::",
-            stringify!(event_connection_info)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1>())).monitor_connection_info
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1),
-            "::",
-            stringify!(monitor_connection_info)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<hv_connection_info__bindgen_ty_1>())).doorbell_connection_info
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info__bindgen_ty_1),
-            "::",
-            stringify!(doorbell_connection_info)
-        )
-    );
-}
-impl Default for hv_connection_info__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[test]
-fn bindgen_test_layout_hv_connection_info() {
-    assert_eq!(
-        ::std::mem::size_of::<hv_connection_info>(),
-        32usize,
-        concat!("Size of: ", stringify!(hv_connection_info))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<hv_connection_info>(),
-        8usize,
-        concat!("Alignment of ", stringify!(hv_connection_info))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<hv_connection_info>())).port_type as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info),
-            "::",
-            stringify!(port_type)
-        )
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<hv_connection_info>())).padding as *const _ as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(hv_connection_info),
-            "::",
-            stringify!(padding)
-        )
-    );
-}
-impl Default for hv_connection_info {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -11113,6 +10414,467 @@ impl Default for hv_translate_gva_result {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+pub union hv_gpa_page_access_state_flags {
+    pub __bindgen_anon_1: hv_gpa_page_access_state_flags__bindgen_ty_1,
+    pub as_uint64: __u64,
+}
+#[repr(C)]
+#[derive(Default, Copy, Clone)]
+pub struct hv_gpa_page_access_state_flags__bindgen_ty_1 {
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
+}
+#[test]
+fn bindgen_test_layout_hv_gpa_page_access_state_flags__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_gpa_page_access_state_flags__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Size of: ",
+            stringify!(hv_gpa_page_access_state_flags__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_gpa_page_access_state_flags__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(hv_gpa_page_access_state_flags__bindgen_ty_1)
+        )
+    );
+}
+impl hv_gpa_page_access_state_flags__bindgen_ty_1 {
+    #[inline]
+    pub fn clear_accessed(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_clear_accessed(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn set_access(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_set_access(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn clear_dirty(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_clear_dirty(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn set_dirty(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_set_dirty(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn reserved(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 60u8) as u64) }
+    }
+    #[inline]
+    pub fn set_reserved(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 60u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        clear_accessed: __u64,
+        set_access: __u64,
+        clear_dirty: __u64,
+        set_dirty: __u64,
+        reserved: __u64,
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let clear_accessed: u64 = unsafe { ::std::mem::transmute(clear_accessed) };
+            clear_accessed as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let set_access: u64 = unsafe { ::std::mem::transmute(set_access) };
+            set_access as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let clear_dirty: u64 = unsafe { ::std::mem::transmute(clear_dirty) };
+            clear_dirty as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let set_dirty: u64 = unsafe { ::std::mem::transmute(set_dirty) };
+            set_dirty as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 60u8, {
+            let reserved: u64 = unsafe { ::std::mem::transmute(reserved) };
+            reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[test]
+fn bindgen_test_layout_hv_gpa_page_access_state_flags() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_gpa_page_access_state_flags>(),
+        8usize,
+        concat!("Size of: ", stringify!(hv_gpa_page_access_state_flags))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_gpa_page_access_state_flags>(),
+        1usize,
+        concat!("Alignment of ", stringify!(hv_gpa_page_access_state_flags))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hv_gpa_page_access_state_flags>())).as_uint64 as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hv_gpa_page_access_state_flags),
+            "::",
+            stringify!(as_uint64)
+        )
+    );
+}
+impl Default for hv_gpa_page_access_state_flags {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+pub struct hv_input_get_gpa_pages_access_state {
+    pub partition_id: __u64,
+    pub flags: hv_gpa_page_access_state_flags,
+    pub hv_gpa_page_number: __u64,
+}
+#[test]
+fn bindgen_test_layout_hv_input_get_gpa_pages_access_state() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_input_get_gpa_pages_access_state>(),
+        24usize,
+        concat!("Size of: ", stringify!(hv_input_get_gpa_pages_access_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_input_get_gpa_pages_access_state>(),
+        1usize,
+        concat!(
+            "Alignment of ",
+            stringify!(hv_input_get_gpa_pages_access_state)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hv_input_get_gpa_pages_access_state>())).partition_id as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hv_input_get_gpa_pages_access_state),
+            "::",
+            stringify!(partition_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hv_input_get_gpa_pages_access_state>())).flags as *const _
+                as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hv_input_get_gpa_pages_access_state),
+            "::",
+            stringify!(flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hv_input_get_gpa_pages_access_state>())).hv_gpa_page_number
+                as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hv_input_get_gpa_pages_access_state),
+            "::",
+            stringify!(hv_gpa_page_number)
+        )
+    );
+}
+impl Default for hv_input_get_gpa_pages_access_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+pub union hv_gpa_page_access_state {
+    pub __bindgen_anon_1: hv_gpa_page_access_state__bindgen_ty_1,
+    pub as_uint8: __u8,
+}
+#[repr(C, packed)]
+#[derive(Default, Copy, Clone)]
+pub struct hv_gpa_page_access_state__bindgen_ty_1 {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+}
+#[test]
+fn bindgen_test_layout_hv_gpa_page_access_state__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_gpa_page_access_state__bindgen_ty_1>(),
+        1usize,
+        concat!(
+            "Size of: ",
+            stringify!(hv_gpa_page_access_state__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_gpa_page_access_state__bindgen_ty_1>(),
+        1usize,
+        concat!(
+            "Alignment of ",
+            stringify!(hv_gpa_page_access_state__bindgen_ty_1)
+        )
+    );
+}
+impl hv_gpa_page_access_state__bindgen_ty_1 {
+    #[inline]
+    pub fn accessed(&self) -> __u8 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
+    }
+    #[inline]
+    pub fn set_accessed(&mut self, val: __u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn dirty(&self) -> __u8 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
+    }
+    #[inline]
+    pub fn set_dirty(&mut self, val: __u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn reserved(&self) -> __u8 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 6u8) as u8) }
+    }
+    #[inline]
+    pub fn set_reserved(&mut self, val: __u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 6u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        accessed: __u8,
+        dirty: __u8,
+        reserved: __u8,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let accessed: u8 = unsafe { ::std::mem::transmute(accessed) };
+            accessed as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let dirty: u8 = unsafe { ::std::mem::transmute(dirty) };
+            dirty as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 6u8, {
+            let reserved: u8 = unsafe { ::std::mem::transmute(reserved) };
+            reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[test]
+fn bindgen_test_layout_hv_gpa_page_access_state() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_gpa_page_access_state>(),
+        1usize,
+        concat!("Size of: ", stringify!(hv_gpa_page_access_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_gpa_page_access_state>(),
+        1usize,
+        concat!("Alignment of ", stringify!(hv_gpa_page_access_state))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hv_gpa_page_access_state>())).as_uint8 as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hv_gpa_page_access_state),
+            "::",
+            stringify!(as_uint8)
+        )
+    );
+}
+impl Default for hv_gpa_page_access_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+pub union hv_partition_property_page_access_tracking_config {
+    pub __bindgen_anon_1: hv_partition_property_page_access_tracking_config__bindgen_ty_1,
+    pub as_uint64: __u64,
+}
+#[repr(C)]
+#[derive(Default, Copy, Clone)]
+pub struct hv_partition_property_page_access_tracking_config__bindgen_ty_1 {
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
+}
+#[test]
+fn bindgen_test_layout_hv_partition_property_page_access_tracking_config__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_partition_property_page_access_tracking_config__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Size of: ",
+            stringify!(hv_partition_property_page_access_tracking_config__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_partition_property_page_access_tracking_config__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(hv_partition_property_page_access_tracking_config__bindgen_ty_1)
+        )
+    );
+}
+impl hv_partition_property_page_access_tracking_config__bindgen_ty_1 {
+    #[inline]
+    pub fn enabled(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_enabled(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn granularity(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_granularity(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn reserved(&self) -> __u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 62u8) as u64) }
+    }
+    #[inline]
+    pub fn set_reserved(&mut self, val: __u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 62u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        enabled: __u64,
+        granularity: __u64,
+        reserved: __u64,
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let enabled: u64 = unsafe { ::std::mem::transmute(enabled) };
+            enabled as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let granularity: u64 = unsafe { ::std::mem::transmute(granularity) };
+            granularity as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 62u8, {
+            let reserved: u64 = unsafe { ::std::mem::transmute(reserved) };
+            reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[test]
+fn bindgen_test_layout_hv_partition_property_page_access_tracking_config() {
+    assert_eq!(
+        ::std::mem::size_of::<hv_partition_property_page_access_tracking_config>(),
+        8usize,
+        concat!(
+            "Size of: ",
+            stringify!(hv_partition_property_page_access_tracking_config)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hv_partition_property_page_access_tracking_config>(),
+        1usize,
+        concat!(
+            "Alignment of ",
+            stringify!(hv_partition_property_page_access_tracking_config)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hv_partition_property_page_access_tracking_config>())).as_uint64
+                as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hv_partition_property_page_access_tracking_config),
+            "::",
+            stringify!(as_uint64)
+        )
+    );
+}
+impl Default for hv_partition_property_page_access_tracking_config {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const MSHV_PAGE_ACCESS_TRACKING_GRANULARITY_SMALL_PAGES: ::std::os::raw::c_uint = 0;
+pub const MSHV_PAGE_ACCESS_TRACKING_GRANULARITY_LARGE_PAGES: ::std::os::raw::c_uint = 1;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct mshv_create_partition {
@@ -11590,66 +11352,66 @@ impl Default for mshv_partition_property {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct mshv_vp_translate_gva {
+pub struct mshv_translate_gva {
     pub gva: __u64,
     pub flags: __u64,
     pub result: *mut hv_translate_gva_result,
     pub gpa: *mut __u64,
 }
 #[test]
-fn bindgen_test_layout_mshv_vp_translate_gva() {
+fn bindgen_test_layout_mshv_translate_gva() {
     assert_eq!(
-        ::std::mem::size_of::<mshv_vp_translate_gva>(),
+        ::std::mem::size_of::<mshv_translate_gva>(),
         32usize,
-        concat!("Size of: ", stringify!(mshv_vp_translate_gva))
+        concat!("Size of: ", stringify!(mshv_translate_gva))
     );
     assert_eq!(
-        ::std::mem::align_of::<mshv_vp_translate_gva>(),
+        ::std::mem::align_of::<mshv_translate_gva>(),
         8usize,
-        concat!("Alignment of ", stringify!(mshv_vp_translate_gva))
+        concat!("Alignment of ", stringify!(mshv_translate_gva))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<mshv_vp_translate_gva>())).gva as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<mshv_translate_gva>())).gva as *const _ as usize },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(mshv_vp_translate_gva),
+            stringify!(mshv_translate_gva),
             "::",
             stringify!(gva)
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<mshv_vp_translate_gva>())).flags as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<mshv_translate_gva>())).flags as *const _ as usize },
         8usize,
         concat!(
             "Offset of field: ",
-            stringify!(mshv_vp_translate_gva),
+            stringify!(mshv_translate_gva),
             "::",
             stringify!(flags)
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<mshv_vp_translate_gva>())).result as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<mshv_translate_gva>())).result as *const _ as usize },
         16usize,
         concat!(
             "Offset of field: ",
-            stringify!(mshv_vp_translate_gva),
+            stringify!(mshv_translate_gva),
             "::",
             stringify!(result)
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<mshv_vp_translate_gva>())).gpa as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<mshv_translate_gva>())).gpa as *const _ as usize },
         24usize,
         concat!(
             "Offset of field: ",
-            stringify!(mshv_vp_translate_gva),
+            stringify!(mshv_translate_gva),
             "::",
             stringify!(gpa)
         )
     );
 }
-impl Default for mshv_vp_translate_gva {
+impl Default for mshv_translate_gva {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -11719,7 +11481,7 @@ pub const mshv_ioeventfd_flag_nr_datamatch: ::std::os::raw::c_uint = 0;
 pub const mshv_ioeventfd_flag_nr_pio: ::std::os::raw::c_uint = 1;
 pub const mshv_ioeventfd_flag_nr_deassign: ::std::os::raw::c_uint = 2;
 pub const mshv_ioeventfd_flag_nr_max: ::std::os::raw::c_uint = 3;
-pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct mshv_ioeventfd {
@@ -11917,4 +11679,79 @@ fn bindgen_test_layout_mshv_msi_routing() {
             stringify!(entries)
         )
     );
+}
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+pub struct mshv_get_gpa_pages_access_state {
+    pub count: __u32,
+    pub flags: __u64,
+    pub hv_gpa_page_number: __u64,
+    pub states: *mut hv_gpa_page_access_state,
+}
+#[test]
+fn bindgen_test_layout_mshv_get_gpa_pages_access_state() {
+    assert_eq!(
+        ::std::mem::size_of::<mshv_get_gpa_pages_access_state>(),
+        28usize,
+        concat!("Size of: ", stringify!(mshv_get_gpa_pages_access_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<mshv_get_gpa_pages_access_state>(),
+        1usize,
+        concat!("Alignment of ", stringify!(mshv_get_gpa_pages_access_state))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<mshv_get_gpa_pages_access_state>())).count as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mshv_get_gpa_pages_access_state),
+            "::",
+            stringify!(count)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<mshv_get_gpa_pages_access_state>())).flags as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mshv_get_gpa_pages_access_state),
+            "::",
+            stringify!(flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<mshv_get_gpa_pages_access_state>())).hv_gpa_page_number
+                as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mshv_get_gpa_pages_access_state),
+            "::",
+            stringify!(hv_gpa_page_number)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<mshv_get_gpa_pages_access_state>())).states as *const _ as usize
+        },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mshv_get_gpa_pages_access_state),
+            "::",
+            stringify!(states)
+        )
+    );
+}
+impl Default for mshv_get_gpa_pages_access_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1087,6 +1087,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_run_code() {
+        use libc::c_void;
+
         use super::*;
         use crate::ioctls::system::Mshv;
         use std::io::Write;
@@ -1227,6 +1229,8 @@ mod tests {
             };
         }
         assert!(done);
+        vm.unmap_user_memory(mem_region).unwrap();
+        unsafe { libc::munmap(load_addr as *mut c_void, mem_size) };
     }
     #[test]
     #[ignore]

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -914,7 +914,7 @@ impl VcpuFd {
         let gpa: u64 = 0;
         let result = hv_translate_gva_result { as_uint64: 0 };
 
-        let mut args = mshv_vp_translate_gva {
+        let mut args = mshv_translate_gva {
             gva,
             flags,
             gpa: &gpa as *const _ as *mut u64,

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -6,12 +6,16 @@ use crate::ioctls::vcpu::{new_vcpu, VcpuFd};
 use crate::ioctls::Result;
 use crate::mshv_ioctls::*;
 use mshv_bindings::*;
+
+use std::cmp;
 use std::fs::File;
 
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref};
+
+const PAGE_ACCESS_STATES_BATCH_SIZE: u32 = 0x10000;
 
 /// An address either in programmable I/O space or in memory mapped I/O space.
 ///
@@ -390,7 +394,7 @@ impl VmFd {
         };
         #[allow(clippy::cast_lossless)]
         let ret =
-            unsafe { ioctl_with_mut_ref(&self.vm, HV_GET_PARTITION_PROPERTY(), &mut property) };
+            unsafe { ioctl_with_mut_ref(&self.vm, MSHV_GET_PARTITION_PROPERTY(), &mut property) };
         if ret == 0 {
             Ok(property.property_value)
         } else {
@@ -406,7 +410,7 @@ impl VmFd {
             property_value: value,
         };
         #[allow(clippy::cast_lossless)]
-        let ret = unsafe { ioctl_with_ref(&self.vm, HV_SET_PARTITION_PROPERTY(), &property) };
+        let ret = unsafe { ioctl_with_ref(&self.vm, MSHV_SET_PARTITION_PROPERTY(), &property) };
         if ret == 0 {
             Ok(())
         } else {
@@ -481,6 +485,62 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
+    ///
+    /// Gets the bitmap of pages dirtied since the last call of this function
+    ///
+    /// Flags:
+    ///         bit 1: ClearAccessed
+    ///         bit 2: SetAccessed
+    ///         bit 3: ClearDirty
+    ///         bit 4: SetDirty
+    ///         Number of bits reserved: 60
+    ///
+    pub fn get_dirty_log(&self, base_pfn: u64, memory_size: usize, flags: u64) -> Result<Vec<u64>> {
+        // Compute the length of the bitmap needed for all dirty pages in one memory slot.
+        // One memory page is `page_size` bytes and `KVM_GET_DIRTY_LOG` returns one dirty bit for
+        // each page.
+        let page_size = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
+            -1 => return Err(errno::Error::last()),
+            ps => ps as usize,
+        };
+
+        // For ease of access we are saving the bitmap in a u64 vector. We are using ceil to
+        // make sure we count all dirty pages even when `memory_size` is not a multiple of
+        // `page_size * 64`.
+        let div_ceil = |dividend, divisor| (dividend + divisor - 1) / divisor;
+        let bitmap_size = div_ceil(memory_size, page_size * 64);
+        let mut bitmap = vec![0u64; bitmap_size];
+
+        let mut processed: usize = 0;
+        let mut mask;
+        let mut state: u8;
+        let mut current_size;
+        let mut remaining = (memory_size / page_size) as u32;
+        let mut bit_index = 0;
+        let mut bitmap_index = 0;
+
+        while remaining != 0 {
+            current_size = cmp::min(PAGE_ACCESS_STATES_BATCH_SIZE, remaining);
+            let page_states =
+                self.get_gpa_access_state(base_pfn + processed as u64, current_size, flags)?;
+            let slices: &[hv_gpa_page_access_state] = unsafe {
+                std::slice::from_raw_parts(page_states.states, page_states.count as usize)
+            };
+            for (pos, item) in slices.iter().enumerate() {
+                let mut bits = &mut bitmap[bitmap_index];
+                mask = 1 << bit_index;
+                state = unsafe { item.__bindgen_anon_1.dirty() };
+                if state == 1 {
+                    *bits |= mask;
+                }
+                processed += 1;
+                bitmap_index = processed / 64;
+                bit_index = processed % 64;
+            }
+            remaining -= page_states.count;
+        }
+        Ok(bitmap)
+    }
 }
 /// Helper function to create a new `VmFd`.
 ///
@@ -492,6 +552,8 @@ pub fn new_vmfd(vm: File) -> VmFd {
 }
 #[cfg(test)]
 mod tests {
+    use libc::c_void;
+
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
     use crate::ioctls::system::Mshv;
@@ -620,5 +682,39 @@ mod tests {
         let vm = hv.create_vm().unwrap();
         let msi_routing = mshv_msi_routing::default();
         assert!(vm.set_msi_routing(&msi_routing).is_ok());
+    }
+    #[test]
+    #[ignore]
+    fn test_get_gpa_access_states() {
+        let hv = Mshv::new().unwrap();
+        let vm = hv.create_vm().unwrap();
+        // Try to allocate 32 MB memory
+        let mem_size = 32 * 1024 * 1024;
+        let load_addr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                mem_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
+                -1,
+                0,
+            )
+        } as *mut u8;
+        let mem_region = mshv_user_mem_region {
+            flags: HV_MAP_GPA_READABLE | HV_MAP_GPA_WRITABLE | HV_MAP_GPA_EXECUTABLE,
+            guest_pfn: 0x0_u64,
+            size: mem_size as u64,
+            userspace_addr: load_addr as u64,
+        };
+        // TODO need more real time testing: validating data,
+        // number of bits returned etc.
+        vm.map_user_memory(mem_region).unwrap();
+        vm.enable_dirty_page_tracking().unwrap();
+        let bitmaps_1: Vec<u64> = vm.get_dirty_log(0, mem_size, 0x4).unwrap();
+        let bitmaps_2: Vec<u64> = vm.get_dirty_log(0, mem_size, 0x8).unwrap();
+        vm.disable_dirty_page_tracking().unwrap();
+        assert!(bitmaps_1.len() == bitmaps_2.len());
+        vm.unmap_user_memory(mem_region).unwrap();
+        unsafe { libc::munmap(load_addr as *mut c_void, mem_size) };
     }
 }

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -413,6 +413,34 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
+    ///
+    /// Enable dirty page tracking by hypervisor
+    /// Flags:
+    ///         bit 1: Enabled
+    ///         bit 2: Granularity
+    ///
+    pub fn enable_dirty_page_tracking(&self) -> Result<()> {
+        let flag: u64 = 0x1;
+        self.set_partition_property(
+            hv_partition_property_code_HV_PARTITION_PROPERTY_GPA_PAGE_ACCESS_TRACKING,
+            flag,
+        )
+    }
+    ///
+    /// Disable dirty page tracking by hypervisor
+    /// Prerequisite: It is required to set the dirty bits if cleared
+    /// previously, otherwise this hypercall will be failed.
+    /// Flags:
+    ///         bit 1: Enabled
+    ///         bit 2: Granularity
+    ///
+    pub fn disable_dirty_page_tracking(&self) -> Result<()> {
+        let flag: u64 = 0x0;
+        self.set_partition_property(
+            hv_partition_property_code_HV_PARTITION_PROPERTY_GPA_PAGE_ACCESS_TRACKING,
+            flag,
+        )
+    }
 }
 /// Helper function to create a new `VmFd`.
 ///

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -98,7 +98,7 @@ impl VmFd {
     ///
     /// Unmap a guest physical memory.
     ///
-    pub fn umap_user_memory(&self, user_memory_region: mshv_user_mem_region) -> Result<()> {
+    pub fn unmap_user_memory(&self, user_memory_region: mshv_user_mem_region) -> Result<()> {
         #[allow(clippy::cast_lossless)]
         let ret = unsafe { ioctl_with_ref(self, MSHV_UNMAP_GUEST_MEMORY(), &user_memory_region) };
         if ret == 0 {
@@ -452,7 +452,7 @@ mod tests {
 
         vm.map_user_memory(mem).unwrap();
 
-        vm.umap_user_memory(mem).unwrap();
+        vm.unmap_user_memory(mem).unwrap();
     }
     #[test]
     #[ignore]

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -55,9 +55,4 @@ ioctl_iow_nr!(
     0x09,
     mshv_assert_interrupt
 );
-ioctl_iowr_nr!(
-    MSHV_VP_TRANSLATE_GVA,
-    MSHV_IOCTL,
-    0x0E,
-    mshv_vp_translate_gva
-);
+ioctl_iowr_nr!(MSHV_VP_TRANSLATE_GVA, MSHV_IOCTL, 0x0E, mshv_translate_gva);

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -17,13 +17,13 @@ ioctl_iow_nr!(
     mshv_create_partition
 );
 ioctl_iow_nr!(
-    HV_SET_PARTITION_PROPERTY,
+    MSHV_SET_PARTITION_PROPERTY,
     MSHV_IOCTL,
     0x0C,
     mshv_partition_property
 );
 ioctl_iowr_nr!(
-    HV_GET_PARTITION_PROPERTY,
+    MSHV_GET_PARTITION_PROPERTY,
     MSHV_IOCTL,
     0x0D,
     mshv_partition_property

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -56,3 +56,9 @@ ioctl_iow_nr!(
     mshv_assert_interrupt
 );
 ioctl_iowr_nr!(MSHV_VP_TRANSLATE_GVA, MSHV_IOCTL, 0x0E, mshv_translate_gva);
+ioctl_iowr_nr!(
+    MSHV_GET_GPA_ACCESS_STATES,
+    MSHV_IOCTL,
+    0x12,
+    mshv_get_gpa_pages_access_state
+);


### PR DESCRIPTION
This PR updates the bindings that have the /dev/mshv API to retrieve the dirty page access states. There is also an API in MSHV crates to process the page states and convert them to a bitmap compatible with CLH live migration framework.

These are the last set of patches that were merged to cloud-hypervisor while the previous PR was pending. All the patches were cherry-picked from the Cloud Hypervisor project. After this PR both rust-vmm and CLH  repos are synced and we can move all the referent of these crates to rust-vmm.