### PR TITLE
Enable more Synthetic features for guest performance

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 22.70,
+  "coverage_score": 22.60,
   "exclude_path": "",
   "crate_features": "with-serde,fam-wrappers"
 }

--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -4,6 +4,7 @@
 //
 
 use crate::bindings::*;
+use crate::hvdef::HV_X64_MSR_GUEST_OS_ID;
 #[cfg(feature = "with-serde")]
 use serde_derive::{Deserialize, Serialize};
 use std::cmp;
@@ -329,6 +330,7 @@ pub fn msr_to_hv_reg_name(msr: u32) -> Result<hv_register_name, &'static str> {
         IA32_MSR_DEBUG_CTL => Ok(hv_register_name::HV_X64_REGISTER_DEBUG_CTL),
         IA32_MSR_TSC_ADJUST => Ok(hv_register_name::HV_X64_REGISTER_TSC_ADJUST),
         IA32_MSR_SPEC_CTRL => Ok(hv_register_name::HV_X64_REGISTER_SPEC_CTRL),
+        HV_X64_MSR_GUEST_OS_ID => Ok(hv_register_name::HV_REGISTER_GUEST_OS_ID),
 
         IA32_MSR_MISC_ENABLE => Ok(hv_register_name::HV_X64_REGISTER_MSR_IA32_MISC_ENABLE),
         _ => Err("Not a supported hv_register_name msr"),

--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -693,3 +693,9 @@ pub struct SuspendRegisters {
     pub explicit_register: u64,
     pub intercept_register: u64,
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+pub struct MiscRegs {
+    pub hypercall: u64,
+}

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -182,6 +182,7 @@ impl Mshv {
             IA32_MSR_DEBUG_CTL,
             IA32_MSR_SPEC_CTRL,
             //IA32_MSR_TSC_ADJUST, // Current hypervisor version does not allow to get this MSR, need to check later
+            HV_X64_MSR_GUEST_OS_ID,
         ])
         .unwrap())
     }
@@ -204,7 +205,7 @@ mod tests {
     fn test_get_msr_index_list() {
         let hv = Mshv::new().unwrap();
         let msr_list = hv.get_msr_index_list().unwrap();
-        assert!(msr_list.as_fam_struct_ref().nmsrs == 44);
+        assert!(msr_list.as_fam_struct_ref().nmsrs == 45);
 
         let mut found = false;
         for index in msr_list.as_slice() {

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -110,6 +110,14 @@ impl Mshv {
             pr.synthetic_processor_features
                 .__bindgen_anon_1
                 .set_access_guest_idle_reg(1);
+            /* Enable TLB flush hypercalls */
+            pr.synthetic_processor_features
+                .__bindgen_anon_1
+                .set_tb_flush_hypercalls(1);
+            /* Enable synthetic cluster ipi */
+            pr.synthetic_processor_features
+                .__bindgen_anon_1
+                .set_synthetic_cluster_ipi(1);
         }
 
         let ret = unsafe { ioctl_with_ref(&self.hv, MSHV_CREATE_PARTITION(), &pr) };

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1357,4 +1357,16 @@ mod tests {
         assert!(regs.explicit_register == 0x1);
         assert!(regs.intercept_register == 0x0);
     }
+    #[test]
+    #[ignore]
+    fn test_set_get_misc_regs() {
+        let hv = Mshv::new().unwrap();
+        let vm = hv.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+
+        let s_regs = vcpu.get_misc_regs().unwrap();
+        vcpu.set_misc_regs(&s_regs).unwrap();
+        let g_regs = vcpu.get_misc_regs().unwrap();
+        assert!(g_regs.hypercall == s_regs.hypercall);
+    }
 }

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -783,6 +783,32 @@ impl VcpuFd {
             ..Default::default()
         }])
     }
+    /// X86 specific call that returns the vcpu's current "misc registers".
+    pub fn get_misc_regs(&self) -> Result<MiscRegs> {
+        let mut reg_assocs: [hv_register_assoc; 1] = [hv_register_assoc {
+            name: hv_register_name::HV_X64_REGISTER_HYPERCALL as u32,
+            ..Default::default()
+        }];
+        self.get_reg(&mut reg_assocs)?;
+
+        let ret_regs = unsafe {
+            MiscRegs {
+                hypercall: reg_assocs[0].value.reg64,
+            }
+        };
+
+        Ok(ret_regs)
+    }
+    /// X86 specific call that sets the vcpu's current "misc registers".
+    pub fn set_misc_regs(&self, misc: &MiscRegs) -> Result<()> {
+        self.set_reg(&[hv_register_assoc {
+            name: hv_register_name::HV_X64_REGISTER_HYPERCALL as u32,
+            value: hv_register_value {
+                reg64: misc.hypercall,
+            },
+            ..Default::default()
+        }])
+    }
     /// Returns the VCpu state. This IOCTLs can be used to get XSave and LAPIC state.
     pub fn get_vp_state_ioctl(&self, state: &mshv_vp_state) -> Result<()> {
         // Safe because we know that our file is a vCPU fd and we verify the return result.


### PR DESCRIPTION
Enabled TLB flush and IPI synthetic features, added missing Hypercall register and GUEST_OS_ID MSR