### PR TITLE
mshv: fix style issues in comments

### DIFF
--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -20,38 +20,30 @@ impl<T> __IncompleteArrayField<T> {
     }
 
     #[inline]
-    ///
     /// # Safety
     /// Safe Beacuse we know the size of the field.
     /// Caller needs to make sure lossless conversion
-    ///
     pub unsafe fn as_ptr(&self) -> *const T {
         ::std::mem::transmute(self)
     }
     #[inline]
-    ///
     /// # Safety
     /// Safe Beacuse we know the size of the field.
     /// Caller needs to make sure lossless conversion
-    ///
     pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
         ::std::mem::transmute(self)
     }
     #[inline]
-    ///
     /// # Safety
     /// Safe Beacuse we know the size of the field.
     /// Caller needs to make sure lossless conversion
-    ///
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
         ::std::slice::from_raw_parts(self.as_ptr(), len)
     }
     #[inline]
-    ///
     /// # Safety
     /// Safe Beacuse we know the size of the field.
     /// Caller needs to make sure lossless conversion
-    ///
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
         ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
     }
@@ -103,7 +95,7 @@ pub struct SegmentRegister {
     pub type_: u8,   /* type, writeable etc: 4 */
     pub present: u8, /* if not present, exception generated: 1 */
     pub dpl: u8,     /* descriptor privilege level (ring): 2 */
-    pub db: u8,      /* default/big (16 or 32 bit size offset): 1*/
+    pub db: u8,      /* default/big (16 or 32 bit size offset): 1 */
     pub s: u8,       /* non-system segment */
     pub l: u8,       /* long (64 bit): 1 */
     pub g: u8,       /* granularity (bytes or 4096 byte pages): 1 */
@@ -455,7 +447,6 @@ impl Default for hv_register_value {
 } */
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-///
 /// This struct normalizes the actual mhsv XSave structure
 /// XSave only used in save and restore functionalities, serilization and
 /// deserialization are needed. Putting all the fields into a single buffer makes
@@ -465,7 +456,6 @@ impl Default for hv_register_value {
 /// states: 8 bytes
 /// data_size: 8 bytes
 /// Actual xsave buffer: 4096 bytes
-///
 pub struct XSave {
     pub buffer: [::std::os::raw::c_char; 4120usize],
 }

--- a/mshv-ioctls/src/ioctls/device.rs
+++ b/mshv-ioctls/src/ioctls/device.rs
@@ -22,7 +22,6 @@ impl DeviceFd {
     /// # Arguments
     ///
     /// * `device_attr` - The device attribute to be tested. `addr` field is ignored.
-    ///
     pub fn has_device_attr(&self, device_attr: &mshv_device_attr) -> Result<()> {
         let ret = unsafe { ioctl_with_ref(self, MSHV_HAS_DEVICE_ATTR(), device_attr) };
         if ret != 0 {
@@ -72,7 +71,6 @@ impl DeviceFd {
     ///     device_fd.set_device_attr(&dist_attr).unwrap();
     /// }
     /// ```
-    ///
     pub fn set_device_attr(&self, device_attr: &mshv_device_attr) -> Result<()> {
         let ret = unsafe { ioctl_with_ref(self, MSHV_SET_DEVICE_ATTR(), device_attr) };
         if ret != 0 {
@@ -100,7 +98,6 @@ impl DeviceFd {
     /// * Returns the last occured `errno` wrapped in an `Err`.
     /// * `device_attr` - The `addr` field of the `device_attr` structure will point to
     ///                   the device attribute data.
-    ///
     pub fn get_device_attr(&self, device_attr: &mut mshv_device_attr) -> Result<()> {
         let ret = unsafe { ioctl_with_mut_ref(self, MSHV_GET_DEVICE_ATTR(), device_attr) };
         if ret != 0 {

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -19,9 +19,7 @@ pub struct Mshv {
 }
 
 impl Mshv {
-    ///
     /// Opens `/dev/mshv` and returns a `Mshv` object on success.
-    ///
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Result<Self> {
         // Open `/dev/mshv` using `O_CLOEXEC` flag.
@@ -30,7 +28,6 @@ impl Mshv {
         let ret = unsafe { Self::new_with_fd_number(fd) };
         Ok(ret)
     }
-    ///
     /// Creates a new Mshv object assuming `fd` represents an existing open file descriptor
     /// associated with `/dev/mshv`.
     ///
@@ -42,16 +39,13 @@ impl Mshv {
     /// that relies on it being true.
     ///
     /// The caller of this method must make sure the fd is valid and nothing else uses it.
-    ///
     pub unsafe fn new_with_fd_number(fd: RawFd) -> Self {
         Mshv {
             hv: File::from_raw_fd(fd),
         }
     }
 
-    ///
     /// Opens `/dev/mshv` and returns the fd number on success.
-    ///
     pub fn open_with_cloexec(close_on_exec: bool) -> Result<RawFd> {
         let open_flags = O_NONBLOCK | if close_on_exec { O_CLOEXEC } else { 0 };
         // Safe because we give a constant nul-terminated string and verify the result.
@@ -62,9 +56,7 @@ impl Mshv {
             Ok(ret)
         }
     }
-    ///
     /// Creates a VM fd using the MSHV fd.
-    ///
     pub fn create_vm(&self) -> Result<VmFd> {
         // Safe because we know `self.hv` is a real MSHV fd as this module is the only one that
         // creates mshv objects.
@@ -129,9 +121,7 @@ impl Mshv {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Check if MSHV API is stable
-    ///
     pub fn check_stable(&self) -> Result<bool> {
         // Safe because we know `self.hv` is a real MSHV fd as this module is the only one that
         // creates mshv objects.
@@ -143,9 +133,7 @@ impl Mshv {
             _ => Err(errno::Error::last()),
         }
     }
-    ///
     /// X86 specific call to get list of supported MSRS
-    ///
     pub fn get_msr_index_list(&self) -> Result<MsrList> {
         /* return all the MSRs we currently support */
         Ok(MsrList::from_entries(&[

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -18,7 +18,6 @@ use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref};
 // Arguments:
 ///             1. vcpud fd
 ///             2. Array of Tuples of Register name and reguster value Example [(n1, v1), (n2,v2) ....]
-///
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! set_registers_64 {
@@ -63,9 +62,7 @@ impl AsRawFd for VcpuFd {
 }
 
 impl VcpuFd {
-    ///
     /// Get the register values by providing an array of register names
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn get_reg(&self, reg_names: &mut [hv_register_assoc]) -> Result<()> {
         //TODO: Error if input register len is zero
@@ -83,14 +80,12 @@ impl VcpuFd {
         }
         Ok(())
     }
-    ///
     /// Sets a vCPU register to input value.
     ///
     /// # Arguments
     ///
     /// * `reg_name` - general purpose register name.
     /// * `reg_value` - register value.
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn set_reg(&self, regs: &[hv_register_assoc]) -> Result<()> {
         let hv_vp_register_args = mshv_vp_registers {
@@ -103,9 +98,7 @@ impl VcpuFd {
         }
         Ok(())
     }
-    ///
     /// Sets the vCPU general purpose registers
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn set_regs(&self, regs: &StandardRegisters) -> Result<()> {
         let reg_assocs = [
@@ -204,9 +197,7 @@ impl VcpuFd {
         Ok(())
     }
 
-    ///
     /// Returns the vCPU general purpose registers.
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn get_regs(&self) -> Result<StandardRegisters> {
         let reg_names = [
@@ -261,9 +252,7 @@ impl VcpuFd {
 
         Ok(ret_regs)
     }
-    ///
     /// Returns the vCPU special registers.
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn get_sregs(&self) -> Result<SpecialRegisters> {
         let reg_names: [hv_register_name; 18] = [
@@ -333,9 +322,7 @@ impl VcpuFd {
 
         Ok(ret_regs)
     }
-    ///
     /// Sets the vCPU special registers
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn set_sregs(&self, sregs: &SpecialRegisters) -> Result<()> {
         let reg_names: [hv_register_name; 17] = [
@@ -419,9 +406,7 @@ impl VcpuFd {
         self.set_reg(&reg_assocs)?;
         Ok(())
     }
-    ///
     /// Sets the vCPU floating point registers
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn set_fpu(&self, fpu: &FloatingPointUnit) -> Result<()> {
         let reg_names: [hv_register_name; 26] = [
@@ -511,9 +496,7 @@ impl VcpuFd {
         self.set_reg(&reg_assocs)?;
         Ok(())
     }
-    ///
     /// Returns the floating point state (FPU) from the vCPU.
-    ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn get_fpu(&self) -> Result<FloatingPointUnit> {
         let reg_names: [hv_register_name; 26] = [
@@ -590,9 +573,7 @@ impl VcpuFd {
 
         Ok(ret_regs)
     }
-    ///
     /// X86 specific call that returns the vcpu's current "debug registers".
-    ///
     pub fn get_debug_regs(&self) -> Result<DebugRegisters> {
         let reg_names: [hv_register_name; 6] = [
             hv_register_name::HV_X64_REGISTER_DR0,
@@ -626,9 +607,7 @@ impl VcpuFd {
 
         Ok(ret_regs)
     }
-    ///
     /// X86 specific call that sets the vcpu's current "debug registers".
-    ///
     pub fn set_debug_regs(&self, d_regs: &DebugRegisters) -> Result<()> {
         let reg_names = [
             hv_register_name::HV_X64_REGISTER_DR0,
@@ -660,9 +639,7 @@ impl VcpuFd {
         self.set_reg(&reg_assocs)?;
         Ok(())
     }
-    ///
     /// Returns the machine-specific registers (MSR) for this vCPU.
-    ///
     pub fn get_msrs(&self, msrs: &mut Msrs) -> Result<usize> {
         let nmsrs = msrs.as_fam_struct_ref().nmsrs as usize;
         let mut reg_assocs: Vec<hv_register_assoc> = Vec::with_capacity(nmsrs);
@@ -684,10 +661,8 @@ impl VcpuFd {
 
         Ok(nmsrs)
     }
-    ///
     /// Setup the model-specific registers (MSR) for this vCPU.
     /// Returns the number of MSR entries actually written.
-    ///
     pub fn set_msrs(&self, msrs: &Msrs) -> Result<usize> {
         let nmsrs = msrs.as_fam_struct_ref().nmsrs as usize;
         let mut reg_assocs: Vec<hv_register_assoc> = Vec::with_capacity(nmsrs);
@@ -705,9 +680,7 @@ impl VcpuFd {
         self.set_reg(&reg_assocs)?;
         Ok(0_usize)
     }
-    ///
     ///  Triggers the running of the current virtual CPU returning an exit reason.
-    ///
     pub fn run(&self, mut hv_message_input: hv_message) -> Result<hv_message> {
         // Safe because we know that our file is a vCPU fd and we verify the return result.
         let ret = unsafe { ioctl_with_ref(self, MSHV_RUN_VP(), &hv_message_input) };
@@ -716,10 +689,8 @@ impl VcpuFd {
         }
         Ok(hv_message_input)
     }
-    ///
     /// Returns currently pending exceptions, interrupts, and NMIs as well as related
     /// states of the vcpu.
-    ///
     pub fn get_vcpu_events(&self) -> Result<VcpuEvents> {
         let reg_names: [hv_register_name; 5] = [
             hv_register_name::HV_REGISTER_PENDING_INTERRUPTION,
@@ -748,9 +719,7 @@ impl VcpuFd {
         }
         Ok(ret_regs)
     }
-    ///
     /// Sets pending exceptions, interrupts, and NMIs as well as related states of the vcpu.
-    ///
     pub fn set_vcpu_events(&self, events: &VcpuEvents) -> Result<()> {
         let reg_names: [hv_register_name; 5] = [
             hv_register_name::HV_REGISTER_PENDING_INTERRUPTION,
@@ -791,9 +760,7 @@ impl VcpuFd {
         self.set_reg(&reg_assocs)?;
         Ok(())
     }
-    ///
     /// X86 specific call that returns the vcpu's current "xcrs".
-    ///
     pub fn get_xcrs(&self) -> Result<Xcrs> {
         let mut reg_assocs: [hv_register_assoc; 1] = [hv_register_assoc {
             name: hv_register_name::HV_X64_REGISTER_XFEM as u32,
@@ -816,9 +783,7 @@ impl VcpuFd {
             ..Default::default()
         }])
     }
-    ///
     /// Returns the VCpu state. This IOCTLs can be used to get XSave and LAPIC state.
-    ///
     pub fn get_vp_state_ioctl(&self, state: &mshv_vp_state) -> Result<()> {
         // Safe because we know that our file is a vCPU fd and we verify the return result.
         let ret = unsafe { ioctl_with_ref(self, MSHV_GET_VP_STATE(), state) };
@@ -827,9 +792,7 @@ impl VcpuFd {
         }
         Ok(())
     }
-    ///
     /// Returns the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
-    ///
     pub fn get_lapic_ioctl(&self) -> Result<hv_local_interrupt_controller_state> {
         let mut vp_state = mshv_vp_state {
             type_: hv_get_set_vp_state_type_HV_GET_SET_VP_STATE_LOCAL_INTERRUPT_CONTROLLER_STATE,
@@ -840,10 +803,8 @@ impl VcpuFd {
         let state: hv_local_interrupt_controller_state = unsafe { *vp_state.buf.lapic };
         Ok(state)
     }
-    ///
     /// Set vp states (LAPIC, XSave etc)
     /// Test code already covered by get/set_lapic/xsave
-    ///
     pub fn set_vp_state_ioctl(&self, state: &mshv_vp_state) -> Result<()> {
         let ret = unsafe { ioctl_with_ref(self, MSHV_SET_VP_STATE(), state) };
         if ret != 0 {
@@ -851,25 +812,19 @@ impl VcpuFd {
         }
         Ok(())
     }
-    ///
     /// Get the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
-    ///
     pub fn get_lapic(&self) -> Result<LapicState> {
         let state = LapicState::default();
         let vp_state: mshv_vp_state = mshv_vp_state::from(state);
         self.get_vp_state_ioctl(&vp_state)?;
         Ok(LapicState::from(vp_state))
     }
-    ///
     /// Sets the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
-    ///
     pub fn set_lapic(&self, lapic_state: &LapicState) -> Result<()> {
         let vp_state: mshv_vp_state = mshv_vp_state::from(*lapic_state);
         self.set_vp_state_ioctl(&vp_state)
     }
-    ///
     /// Returns the xsave data
-    ///
     pub fn get_xsave(&self) -> Result<XSave> {
         let layout = std::alloc::Layout::from_size_align(0x1000, 0x1000).unwrap();
         let buf = unsafe { std::alloc::alloc(layout) };
@@ -887,9 +842,7 @@ impl VcpuFd {
         }
         Ok(ret)
     }
-    ///
     /// Set the xsave data
-    ///
     pub fn set_xsave(&self, data: &XSave) -> Result<()> {
         let mut vp_state: mshv_vp_state = mshv_vp_state::from(*data);
         let layout = std::alloc::Layout::from_size_align(0x1000, 0x1000).unwrap();
@@ -907,9 +860,7 @@ impl VcpuFd {
         }
         ret
     }
-    ///
     /// Translate guest virtual address to guest physical address
-    ///
     pub fn translate_gva(&self, gva: u64, flags: u64) -> Result<(u64, hv_translate_gva_result)> {
         let gpa: u64 = 0;
         let result = hv_translate_gva_result { as_uint64: 0 };
@@ -928,9 +879,7 @@ impl VcpuFd {
 
         Ok((gpa, result))
     }
-    ///
     /// X86 specific call that returns the vcpu's current "suspend registers".
-    ///
     pub fn get_suspend_regs(&self) -> Result<SuspendRegisters> {
         let reg_names: [hv_register_name; 2] = [
             hv_register_name::HV_REGISTER_EXPLICIT_SUSPEND,

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -22,7 +22,6 @@ const PAGE_ACCESS_STATES_BATCH_SIZE: u32 = 0x10000;
 ///
 /// The `IoEventAddress` is used for specifying the type when registering an event
 /// in [register_ioevent](struct.VmFd.html#method.register_ioevent).
-///
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Copy)]
 pub enum IoEventAddress {
     /// Representation of an programmable I/O address.
@@ -36,7 +35,6 @@ pub enum IoEventAddress {
 /// The structure can be used as a parameter to
 /// [`register_ioevent`](struct.VmFd.html#method.register_ioevent)
 /// to disable filtering of events based on the datamatch flag.
-///
 pub struct NoDatamatch;
 
 impl From<NoDatamatch> for u64 {
@@ -54,7 +52,6 @@ impl From<NoDatamatch> for u64 {
 ///     level_triggered: True means level triggered, false means edge triggered
 ///     logical_destination_mode: lTrue means the APIC ID is logical, false means physical
 ///     long_mode: True means CPU is in long mode
-///
 pub struct InterruptRequest {
     pub interrupt_type: hv_interrupt_type,
     pub apic_id: u64,
@@ -75,9 +72,7 @@ impl AsRawFd for VmFd {
 }
 
 impl VmFd {
-    ///
     /// Install intercept to enable some VM exits like MSR, CPUId etc
-    ///
     pub fn install_intercept(&self, install_intercept_args: mshv_install_intercept) -> Result<()> {
         #[allow(clippy::cast_lossless)]
         let ret =
@@ -88,9 +83,7 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Creates/modifies a guest physical memory.
-    ///
     pub fn map_user_memory(&self, user_memory_region: mshv_user_mem_region) -> Result<()> {
         #[allow(clippy::cast_lossless)]
         let ret = unsafe { ioctl_with_ref(self, MSHV_MAP_GUEST_MEMORY(), &user_memory_region) };
@@ -100,9 +93,7 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Unmap a guest physical memory.
-    ///
     pub fn unmap_user_memory(&self, user_memory_region: mshv_user_mem_region) -> Result<()> {
         #[allow(clippy::cast_lossless)]
         let ret = unsafe { ioctl_with_ref(self, MSHV_UNMAP_GUEST_MEMORY(), &user_memory_region) };
@@ -112,9 +103,7 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Creates a new MSHV vCPU file descriptor
-    ///
     pub fn create_vcpu(&self, id: u8) -> Result<VcpuFd> {
         let vp_arg = mshv_create_vp {
             vp_index: id as __u32,
@@ -132,9 +121,7 @@ impl VmFd {
 
         Ok(new_vcpu(vcpu))
     }
-    ///
     /// Inject an interrupt into the guest..
-    ///
     pub fn request_virtual_interrupt(&self, request: &InterruptRequest) -> Result<()> {
         let mut control_flags: u32 = 0;
         if request.level_triggered {
@@ -162,10 +149,8 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// irqfd: Passes in an eventfd which is to be used for injecting
     /// interrupts from userland.
-    ///
     fn irqfd(&self, fd: RawFd, gsi: u32, flags: u32) -> Result<()> {
         let mut irqfd_arg = mshv_irqfd {
             fd: fd as i32,
@@ -203,7 +188,6 @@ impl VmFd {
     /// let evtfd = EventFd::new(EFD_NONBLOCK).unwrap();
     /// vm.register_irqfd(&evtfd, 30).unwrap();
     /// ```
-    ///
     pub fn register_irqfd(&self, fd: &EventFd, gsi: u32) -> Result<()> {
         self.irqfd(fd.as_raw_fd(), gsi, 0)
     }
@@ -228,7 +212,6 @@ impl VmFd {
     /// vm.register_irqfd(&evtfd, 30).unwrap();
     /// vm.unregister_irqfd(&evtfd, 30).unwrap();
     /// ```
-    ///
     pub fn unregister_irqfd(&self, fd: &EventFd, gsi: u32) -> Result<()> {
         self.irqfd(fd.as_raw_fd(), gsi, MSHV_IRQFD_FLAG_DEASSIGN)
     }
@@ -256,7 +239,6 @@ impl VmFd {
     /// let msi_routing = mshv_msi_routing::default();
     /// vm.set_msi_routing(&msi_routing).unwrap();
     /// ```
-    ///
     pub fn set_msi_routing(&self, msi_routing: &mshv_msi_routing) -> Result<()> {
         // Safe because we allocated the structure and we know the kernel
         // will read exactly the size of the structure.
@@ -268,10 +250,8 @@ impl VmFd {
         }
     }
 
-    ///
     /// ioeventfd: Passes in an eventfd which the kernel would signal when
     /// an mmio region is written into.
-    ///
     fn ioeventfd<T: Into<u64>>(
         &self,
         fd: &EventFd,
@@ -335,9 +315,8 @@ impl VmFd {
     /// let vm = hv.create_vm().unwrap();
     /// let evtfd = EventFd::new(EFD_NONBLOCK).unwrap();
     /// vm.register_ioevent(&evtfd, &IoEventAddress::Mmio(0x1000), NoDatamatch)
-    ///   .unwrap();
+    ///     .unwrap();
     /// ```
-    ///
     pub fn register_ioevent<T: Into<u64>>(
         &self,
         fd: &EventFd,
@@ -370,11 +349,10 @@ impl VmFd {
     /// let vm = hv.create_vm().unwrap();
     /// let evtfd = EventFd::new(EFD_NONBLOCK).unwrap();
     /// vm.register_ioevent(&evtfd, &IoEventAddress::Mmio(0x1000), NoDatamatch)
-    ///   .unwrap();
+    ///     .unwrap();
     /// vm.unregister_ioevent(&evtfd, &IoEventAddress::Mmio(0x1000), NoDatamatch)
-    ///   .unwrap();
+    ///     .unwrap();
     /// ```
-    ///
     pub fn unregister_ioevent<T: Into<u64>>(
         &self,
         fd: &EventFd,
@@ -384,10 +362,8 @@ impl VmFd {
         self.ioeventfd(fd, addr, datamatch, 1 << mshv_ioeventfd_flag_nr_deassign)
     }
 
-    ///
     /// Get property of the VM partition: For example , CPU Frequency, Size of the Xsave state and more.
     /// For more of the codes, please see the hv_partition_property_code type definitions in the bindings.rs
-    ///
     pub fn get_partition_property(&self, code: u32) -> Result<u64> {
         let mut property = mshv_partition_property {
             property_code: code,
@@ -402,9 +378,7 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Sets a partion property
-    ///
     pub fn set_partition_property(&self, code: u32, value: u64) -> Result<()> {
         let property: mshv_partition_property = mshv_partition_property {
             property_code: code,
@@ -418,12 +392,10 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Enable dirty page tracking by hypervisor
     /// Flags:
     ///         bit 1: Enabled
     ///         bit 2: Granularity
-    ///
     pub fn enable_dirty_page_tracking(&self) -> Result<()> {
         let flag: u64 = 0x1;
         self.set_partition_property(
@@ -431,14 +403,12 @@ impl VmFd {
             flag,
         )
     }
-    ///
     /// Disable dirty page tracking by hypervisor
     /// Prerequisite: It is required to set the dirty bits if cleared
     /// previously, otherwise this hypercall will be failed.
     /// Flags:
     ///         bit 1: Enabled
     ///         bit 2: Granularity
-    ///
     pub fn disable_dirty_page_tracking(&self) -> Result<()> {
         let flag: u64 = 0x0;
         self.set_partition_property(
@@ -446,7 +416,6 @@ impl VmFd {
             flag,
         )
     }
-    ///
     /// Get page access state
     /// The data provides each page's access state whether it is dirty or accessed
     /// Prerequisite: Need to enable page_acess_tracking
@@ -456,7 +425,6 @@ impl VmFd {
     ///         bit 3: ClearDirty
     ///         bit 4: SetDirty
     ///         Number of bits reserved: 60
-    ///
     pub fn get_gpa_access_state(
         &self,
         base_pfn: u64,
@@ -486,7 +454,6 @@ impl VmFd {
             Err(errno::Error::last())
         }
     }
-    ///
     /// Gets the bitmap of pages dirtied since the last call of this function
     ///
     /// Flags:
@@ -495,7 +462,6 @@ impl VmFd {
     ///         bit 3: ClearDirty
     ///         bit 4: SetDirty
     ///         Number of bits reserved: 60
-    ///
     pub fn get_dirty_log(&self, base_pfn: u64, memory_size: usize, flags: u64) -> Result<Vec<u64>> {
         // Compute the length of the bitmap needed for all dirty pages in one memory slot.
         // One memory page is `page_size` bytes and `KVM_GET_DIRTY_LOG` returns one dirty bit for
@@ -545,7 +511,6 @@ impl VmFd {
     /// Create an in-kernel device
     ///
     /// See the documentation for `MSHV_CREATE_DEVICE`.
-    ///
     pub fn create_device(&self, device: &mut mshv_create_device) -> Result<DeviceFd> {
         let ret = unsafe { ioctl_with_ref(self, MSHV_CREATE_DEVICE(), device) };
         if ret == 0 {


### PR DESCRIPTION
These issues are detected with rustfmt's format_code_in_doc_comments.

Signed-off-by: Wei Liu <liuwe@microsoft.com>