### PR TITLE
mshv-bindings: fix hv_u128

### DIFF
--- a/mshv-bindings/src/bindings.rs
+++ b/mshv-bindings/src/bindings.rs
@@ -2293,8 +2293,8 @@ pub enum hv_register_name {
 #[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 pub struct hv_u128 {
-    pub high_part: __u64,
     pub low_part: __u64,
+    pub high_part: __u64,
 }
 #[test]
 fn bindgen_test_layout_hv_u128() {
@@ -2310,7 +2310,7 @@ fn bindgen_test_layout_hv_u128() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<hv_u128>())).high_part as *const _ as usize },
-        0usize,
+        8usize,
         concat!(
             "Offset of field: ",
             stringify!(hv_u128),
@@ -2320,7 +2320,7 @@ fn bindgen_test_layout_hv_u128() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<hv_u128>())).low_part as *const _ as usize },
-        8usize,
+        0usize,
         concat!(
             "Offset of field: ",
             stringify!(hv_u128),


### PR DESCRIPTION
### Summary of the PR

The two parts were in the wrong order.

Correct ordering is shown in https://docs.microsoft.com/en-us/virtualization/api/hypervisor-platform/funcs/whvvirtualprocessordatatypes for WHV_UINT128 type.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
