### PR TITLE
Add support for Unimplemented MSR action property

### DIFF
--- a/mshv-bindings/src/bindings.rs
+++ b/mshv-bindings/src/bindings.rs
@@ -1765,6 +1765,13 @@ fn bindgen_test_layout_hv_partition_processor_features() {
         )
     );
 }
+pub const hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_FAULT:
+    hv_unimplemented_msr_action = 0;
+pub const hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO:
+    hv_unimplemented_msr_action = 1;
+pub const hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_COUNT:
+    hv_unimplemented_msr_action = 2;
+pub type hv_unimplemented_msr_action = ::std::os::raw::c_uint;
 impl Default for hv_partition_processor_features {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
@@ -10239,6 +10246,8 @@ pub const hv_partition_property_code_HV_PARTITION_PROPERTY_NON_ARCHITECTURAL_COR
     hv_partition_property_code = 327697;
 pub const hv_partition_property_code_HV_PARTITION_PROPERTY_HYPERCALL_DOORBELL_PAGE:
     hv_partition_property_code = 327698;
+pub const hv_partition_property_code_HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION:
+    hv_partition_property_code = 327703;
 pub const hv_partition_property_code_HV_PARTITION_PROPERTY_PROCESSOR_VENDOR:
     hv_partition_property_code = 393216;
 pub const hv_partition_property_code_HV_PARTITION_PROPERTY_PROCESSOR_FEATURES_DEPRECATED:

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -640,6 +640,20 @@ mod tests {
             0,
         )
         .unwrap();
+        vm.set_partition_property(
+            hv_partition_property_code_HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION,
+            hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO as u64,
+        )
+        .unwrap();
+        val = vm
+            .get_partition_property(
+                hv_partition_property_code_HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION,
+            )
+            .unwrap();
+        assert!(
+            val == hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO
+                .into()
+        );
     }
     #[test]
     #[ignore]


### PR DESCRIPTION
### Summary of the PR

MSHV allows changing the behavior for unimplemented MSRs. If the guest tries to access an unimplemented MSR default behavior is to send a fault to the guest. But this behavior can be overridden by setting the partition property called `UNIMPLEMENTED_MSR_ACTION`. With this PR support for changing this partition property is added, along with it a unit test to validate the behavior.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [Done] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [Done] All added/changed functionality has a corresponding unit/integration
  test.
- [Done] Any newly added `unsafe` code is properly documented.
