### PR TITLE
mshv: Make LDT register a segment register

### DIFF
--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -184,7 +184,7 @@ pub struct SpecialRegisters {
     pub gs: SegmentRegister,
     pub ss: SegmentRegister,
     pub tr: SegmentRegister,
-    pub ldt: TableRegister,
+    pub ldt: SegmentRegister,
     pub gdt: TableRegister,
     pub idt: TableRegister,
     pub cr0: u64,

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -296,7 +296,7 @@ impl VcpuFd {
             ret_regs.gs = SegmentRegister::from(reg_assocs[4].value.segment);
             ret_regs.ss = SegmentRegister::from(reg_assocs[5].value.segment);
             ret_regs.tr = SegmentRegister::from(reg_assocs[6].value.segment);
-            ret_regs.ldt = TableRegister::from(reg_assocs[7].value.table);
+            ret_regs.ldt = SegmentRegister::from(reg_assocs[7].value.segment);
             ret_regs.gdt = TableRegister::from(reg_assocs[8].value.table);
             ret_regs.idt = TableRegister::from(reg_assocs[9].value.table);
             ret_regs.cr0 = reg_assocs[10].value.reg64;
@@ -371,7 +371,7 @@ impl VcpuFd {
                 segment: sregs.tr.into(),
             },
             hv_register_value {
-                table: sregs.ldt.into(),
+                segment: sregs.ldt.into(),
             },
             hv_register_value {
                 table: sregs.gdt.into(),


### PR DESCRIPTION
Currently we are assuming LDT register as a Table Register. Instead it
should be a segment register.

Reported-by: Dev Rajput <t-devrajput@microsoft.com>
Signed-off-by: Jinank Jain <jinankjain@microsoft.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
