### PR TITLE
mshv: Fix get/set for Lapic state

### DIFF
--- a/mshv-bindings/src/bindings.rs
+++ b/mshv-bindings/src/bindings.rs
@@ -10806,7 +10806,7 @@ impl Default for hv_register_assoc {
     }
 }
 pub const hv_get_set_vp_state_type_HV_GET_SET_VP_STATE_LOCAL_INTERRUPT_CONTROLLER_STATE:
-    hv_get_set_vp_state_type = 0;
+    hv_get_set_vp_state_type = -2147483648;
 pub const hv_get_set_vp_state_type_HV_GET_SET_VP_STATE_XSAVE: hv_get_set_vp_state_type =
     -2147483647;
 pub const hv_get_set_vp_state_type_HV_GET_SET_VP_STATE_SIM_PAGE: hv_get_set_vp_state_type =

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -582,9 +582,8 @@ mod tests {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        let state: LapicState = LapicState::default();
-        let mut vp_state: mshv_vp_state = mshv_vp_state::from(state);
-        vcpu.get_vp_state_ioctl(&mut vp_state).unwrap();
+        let state = vcpu.get_lapic().unwrap();
+        let vp_state: mshv_vp_state = mshv_vp_state::from(state);
         let lapic: hv_local_interrupt_controller_state = unsafe { *(vp_state.buf.lapic) };
         let cfg = InterruptRequest {
             interrupt_type: hv_interrupt_type_HV_X64_INTERRUPT_TYPE_EXTINT,


### PR DESCRIPTION
### Summary of the PR

With the new Microsoft Hypervisor binaries, the behavior for getting and
setting Lapic state has been changed. Now we need to provide an
additional buffer which is page aligned to get/set Lapic state from/to
Hypervisor.

While at it remove the useless get_lapic_ioctl() function since that is
not used by anyone. Also this function is bit redudant since we already
have get_lapic_state() and set_lapic_state() which achieves the same
functionality.

As part of this commit mshv-bindings are also updated to reflect the
change in LAPIC state type.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
