### PR TITLE
scripts: Add support for passing bindgen args

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 87.0, "exclude_path": "mshv-bindings", "crate_features": "with-serde,fam-wrappers"}
+{"coverage_score": 87.6, "exclude_path": "mshv-bindings", "crate_features": "with-serde,fam-wrappers"}

--- a/mshv-bindings/src/lib.rs
+++ b/mshv-bindings/src/lib.rs
@@ -9,7 +9,8 @@
 #![allow(
     clippy::too_many_arguments,
     clippy::missing_safety_doc,
-    clippy::upper_case_acronyms
+    clippy::upper_case_acronyms,
+    clippy::useless_transmute
 )]
 #![allow(unknown_lints)]
 #![allow(deref_nullptr)]

--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -63,7 +63,7 @@ impl<T> ::std::clone::Clone for __IncompleteArrayField<T> {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct StandardRegisters {
     pub rax: u64,
@@ -199,7 +199,7 @@ pub struct SpecialRegisters {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct DebugRegisters {
     pub Dr0: u64,
@@ -211,7 +211,7 @@ pub struct DebugRegisters {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct FloatingPointUnit {
     pub fpr: [[u8; 16usize]; 8usize],
@@ -339,7 +339,7 @@ pub fn msr_to_hv_reg_name(msr: u32) -> Result<hv_register_name, &'static str> {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct msr_entry {
     pub index: u32,
@@ -366,7 +366,7 @@ pub struct msr_list {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct VcpuEvents {
     pub pending_interruption: u64,
@@ -376,14 +376,14 @@ pub struct VcpuEvents {
     pub pending_event1: [u8; 16usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct Xcrs {
     pub xcr0: u64,
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct hv_cpuid_entry {
     pub function: __u32,
     pub index: __u32,
@@ -730,14 +730,14 @@ impl XSave {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct SuspendRegisters {
     pub explicit_register: u64,
     pub intercept_register: u64,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct MiscRegs {
     pub hypercall: u64,


### PR DESCRIPTION
The script has an additional parameter called `--bindgen` to pass
bindgen arguments transparently. You can use this new option in the
following way:

```sh
$ ./scripts/generate_binding.py --kernel ../linux-stable --log-level debug
  --bindgen "--with-derive-eq --with-derive-ord"
DEBUG:root:Installing kernel headers at /tmp/linuxiwd2ds3d
DEBUG:root:Start generating unified header file
DEBUG:root:Done generating unified header file
DEBUG:root:Running bindgen:
    bindgen --no-doc-comments --with-derive-default --no-derive-debug
    --with-derive-eq --with-derive-ord --rustified-enum hv_register_name
    /tmp/linuxiwd2ds3d/combined_mshv.h --
    -I /tmp/linuxiwd2ds3d/include > mshv-bindings/src/bindings.rs

DEBUG:root:Cleaning up installed header files
```

Fixes #57

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
