### PR TITLE
mshv-ioctls: Add a new test to check immutable

### DIFF
--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -708,6 +708,19 @@ mod tests {
         vm.install_intercept(intercept_args).unwrap();
     }
     #[test]
+    fn test_setting_immutable_partition_property() {
+        let hv = Mshv::new().unwrap();
+        let vm = hv.create_vm().unwrap();
+        let res = vm.set_partition_property(
+            hv_partition_property_code_HV_PARTITION_PROPERTY_PRIVILEGE_FLAGS,
+            0,
+        );
+
+        // We should get an error, because we are trying to change an immutable
+        // partition property.
+        assert!(res.is_err())
+    }
+    #[test]
     fn test_get_set_property() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
@@ -730,11 +743,6 @@ mod tests {
             )
             .unwrap();
         println!("Processor frequency: {}", val);
-        vm.set_partition_property(
-            hv_partition_property_code_HV_PARTITION_PROPERTY_PRIVILEGE_FLAGS,
-            0,
-        )
-        .unwrap();
         vm.set_partition_property(
             hv_partition_property_code_HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION,
             hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO as u64,


### PR DESCRIPTION
... partition property. One of the partition property was moved to set of immutable partition property. One of the test was trying to mutate it and thus failing the tests. Instead refactor that test to make sure that we get an error if we try to change immutable partition property.

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
