### PR TITLE
mshv-bindings: import vmm_sys_util macros for all architectures

### DIFF
--- a/mshv-bindings/src/lib.rs
+++ b/mshv-bindings/src/lib.rs
@@ -4,10 +4,7 @@
 //
 
 #[macro_use]
-#[cfg(all(
-    feature = "fam-wrappers",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
+#[cfg(feature = "fam-wrappers")]
 extern crate vmm_sys_util;
 
 #[allow(


### PR DESCRIPTION
This should fix building the crate on aarch64.

Signed-off-by: Wei Liu <liuwe@microsoft.com>

### Summary of the PR

See https://github.com/rust-vmm/vfio/pull/17

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
