### PR TITLE
bindings: fix clippy::unnecessary_cast warnings

### DIFF
--- a/mshv-bindings/src/lib.rs
+++ b/mshv-bindings/src/lib.rs
@@ -11,6 +11,7 @@ extern crate vmm_sys_util;
     clippy::too_many_arguments,
     clippy::missing_safety_doc,
     clippy::useless_transmute,
+    clippy::unnecessary_cast,
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -105,92 +105,92 @@ impl VcpuFd {
     pub fn set_regs(&self, regs: &StandardRegisters) -> Result<()> {
         let reg_assocs = [
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RAX as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RAX,
                 value: hv_register_value { reg64: regs.rax },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RBX as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RBX,
                 value: hv_register_value { reg64: regs.rbx },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RCX as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RCX,
                 value: hv_register_value { reg64: regs.rcx },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RDX as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RDX,
                 value: hv_register_value { reg64: regs.rdx },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RSI as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RSI,
                 value: hv_register_value { reg64: regs.rsi },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RDI as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RDI,
                 value: hv_register_value { reg64: regs.rdi },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RSP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RSP,
                 value: hv_register_value { reg64: regs.rsp },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RBP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RBP,
                 value: hv_register_value { reg64: regs.rbp },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R8 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R8,
                 value: hv_register_value { reg64: regs.r8 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R9 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R9,
                 value: hv_register_value { reg64: regs.r9 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R10 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R10,
                 value: hv_register_value { reg64: regs.r10 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R11 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R11,
                 value: hv_register_value { reg64: regs.r11 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R12 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R12,
                 value: hv_register_value { reg64: regs.r12 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R13 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R13,
                 value: hv_register_value { reg64: regs.r13 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R14 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R14,
                 value: hv_register_value { reg64: regs.r14 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_R15 as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_R15,
                 value: hv_register_value { reg64: regs.r15 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RIP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RIP,
                 value: hv_register_value { reg64: regs.rip },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS,
                 value: hv_register_value { reg64: regs.rflags },
                 ..Default::default()
             },
@@ -225,7 +225,7 @@ impl VcpuFd {
         let mut reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()
             .map(|name| hv_register_assoc {
-                name: *name as u32,
+                name: *name,
                 ..Default::default()
             })
             .collect();
@@ -281,7 +281,7 @@ impl VcpuFd {
         let mut reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()
             .map(|name| hv_register_assoc {
-                name: *name as u32,
+                name: *name,
                 ..Default::default()
             })
             .collect();
@@ -402,7 +402,7 @@ impl VcpuFd {
             .iter()
             .zip(reg_values.iter())
             .map(|t| hv_register_assoc {
-                name: *t.0 as u32,
+                name: *t.0,
                 value: *t.1,
                 ..Default::default()
             })
@@ -501,7 +501,7 @@ impl VcpuFd {
             .iter()
             .zip(reg_values.iter())
             .map(|t| hv_register_assoc {
-                name: *t.0 as u32,
+                name: *t.0,
                 value: *t.1,
                 ..Default::default()
             })
@@ -517,7 +517,7 @@ impl VcpuFd {
         let mut reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()
             .map(|name| hv_register_assoc {
-                name: *name as u32,
+                name: *name,
                 ..Default::default()
             })
             .collect();
@@ -577,7 +577,7 @@ impl VcpuFd {
         let mut reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()
             .map(|name| hv_register_assoc {
-                name: *name as u32,
+                name: *name,
                 ..Default::default()
             })
             .collect();
@@ -620,7 +620,7 @@ impl VcpuFd {
             .iter()
             .zip(reg_values.iter())
             .map(|t| hv_register_assoc {
-                name: *t.0 as u32,
+                name: *t.0,
                 value: *t.1,
                 ..Default::default()
             })
@@ -636,7 +636,7 @@ impl VcpuFd {
 
         for i in 0..nmsrs {
             let name = match msr_to_hv_reg_name(msrs.as_slice()[i].index) {
-                Ok(n) => n as u32,
+                Ok(n) => n,
                 Err(_) => return Err(errno::Error::new(libc::EINVAL)),
             };
             reg_assocs.push(hv_register_assoc {
@@ -665,7 +665,7 @@ impl VcpuFd {
 
         for i in 0..nmsrs {
             let name = match msr_to_hv_reg_name(msrs.as_slice()[i].index) {
-                Ok(n) => n as u32,
+                Ok(n) => n,
                 Err(_) => return Err(errno::Error::new(libc::EINVAL)),
             };
             reg_assocs.push(hv_register_assoc {
@@ -702,7 +702,7 @@ impl VcpuFd {
         let mut reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()
             .map(|name| hv_register_assoc {
-                name: *name as u32,
+                name: *name,
                 ..Default::default()
             })
             .collect();
@@ -755,7 +755,7 @@ impl VcpuFd {
             .iter()
             .zip(reg_values.iter())
             .map(|t| hv_register_assoc {
-                name: *t.0 as u32,
+                name: *t.0,
                 value: *t.1,
                 ..Default::default()
             })
@@ -766,7 +766,7 @@ impl VcpuFd {
     /// X86 specific call that returns the vcpu's current "xcrs".
     pub fn get_xcrs(&self) -> Result<Xcrs> {
         let mut reg_assocs: [hv_register_assoc; 1] = [hv_register_assoc {
-            name: hv_x64_register_name_HV_X64_REGISTER_XFEM as u32,
+            name: hv_x64_register_name_HV_X64_REGISTER_XFEM,
             ..Default::default()
         }];
         self.get_reg(&mut reg_assocs)?;
@@ -783,7 +783,7 @@ impl VcpuFd {
     /// X86 specific call to set XCRs
     pub fn set_xcrs(&self, xcrs: &Xcrs) -> Result<()> {
         self.set_reg(&[hv_register_assoc {
-            name: hv_x64_register_name_HV_X64_REGISTER_XFEM as u32,
+            name: hv_x64_register_name_HV_X64_REGISTER_XFEM,
             value: hv_register_value { reg64: xcrs.xcr0 },
             ..Default::default()
         }])
@@ -791,7 +791,7 @@ impl VcpuFd {
     /// X86 specific call that returns the vcpu's current "misc registers".
     pub fn get_misc_regs(&self) -> Result<MiscRegs> {
         let mut reg_assocs: [hv_register_assoc; 1] = [hv_register_assoc {
-            name: hv_x64_register_name_HV_X64_REGISTER_HYPERCALL as u32,
+            name: hv_x64_register_name_HV_X64_REGISTER_HYPERCALL,
             ..Default::default()
         }];
         self.get_reg(&mut reg_assocs)?;
@@ -808,7 +808,7 @@ impl VcpuFd {
     /// X86 specific call that sets the vcpu's current "misc registers".
     pub fn set_misc_regs(&self, misc: &MiscRegs) -> Result<()> {
         self.set_reg(&[hv_register_assoc {
-            name: hv_x64_register_name_HV_X64_REGISTER_HYPERCALL as u32,
+            name: hv_x64_register_name_HV_X64_REGISTER_HYPERCALL,
             value: hv_register_value {
                 reg64: misc.hypercall,
             },
@@ -850,7 +850,7 @@ impl VcpuFd {
     pub fn set_lapic(&self, lapic_state: &LapicState) -> Result<()> {
         let mut vp_state: mshv_vp_state = mshv_vp_state::from(*lapic_state);
         let buffer = Buffer::new(0x1000, 0x1000)?;
-        let min: usize = cmp::min(buffer.size(), vp_state.buf_size as usize) as usize;
+        let min: usize = cmp::min(buffer.size(), vp_state.buf_size as usize);
         // SAFETY: src and dest are valid and properly aligned
         unsafe { ptr::copy(vp_state.buf.bytes, buffer.buf, min) };
         vp_state.buf_size = buffer.size() as u64;
@@ -872,7 +872,7 @@ impl VcpuFd {
     pub fn set_xsave(&self, data: &XSave) -> Result<()> {
         let mut vp_state: mshv_vp_state = mshv_vp_state::from(*data);
         let buffer = Buffer::new(0x1000, 0x1000)?;
-        let min: usize = cmp::min(buffer.size(), vp_state.buf_size as usize) as usize;
+        let min: usize = cmp::min(buffer.size(), vp_state.buf_size as usize);
         // SAFETY: src and dest are valid and properly aligned
         unsafe { ptr::copy(data.buffer.as_ptr().offset(24) as *mut u8, buffer.buf, min) };
         vp_state.buf_size = buffer.size() as u64;
@@ -908,7 +908,7 @@ impl VcpuFd {
         let mut reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()
             .map(|name| hv_register_assoc {
-                name: *name as u32,
+                name: *name,
                 ..Default::default()
             })
             .collect();
@@ -1004,12 +1004,12 @@ mod tests {
 
         vcpu.set_reg(&[
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RIP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RIP,
                 value: hv_register_value { reg64: 0x1000 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS,
                 value: hv_register_value { reg64: 0x2 },
                 ..Default::default()
             },
@@ -1018,11 +1018,11 @@ mod tests {
 
         let mut get_regs: [hv_register_assoc; 2] = [
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RIP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RIP,
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS,
                 ..Default::default()
             },
         ];
@@ -1164,7 +1164,7 @@ mod tests {
 
         //Get CS Register
         let mut cs_reg = hv_register_assoc {
-            name: hv_x64_register_name_HV_X64_REGISTER_CS as u32,
+            name: hv_x64_register_name_HV_X64_REGISTER_CS,
             ..Default::default()
         };
         vcpu.get_reg(slice::from_mut(&mut cs_reg)).unwrap();
@@ -1180,22 +1180,22 @@ mod tests {
         vcpu.set_reg(&[
             cs_reg,
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RAX as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RAX,
                 value: hv_register_value { reg64: 2 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RBX as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RBX,
                 value: hv_register_value { reg64: 2 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RIP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RIP,
                 value: hv_register_value { reg64: 0x1000 },
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS,
                 value: hv_register_value { reg64: 0x2 },
                 ..Default::default()
             },
@@ -1227,7 +1227,7 @@ mod tests {
                         done = true;
                         /* Advance rip */
                         vcpu.set_reg(&[hv_register_assoc {
-                            name: hv_x64_register_name_HV_X64_REGISTER_RIP as u32,
+                            name: hv_x64_register_name_HV_X64_REGISTER_RIP,
                             value: hv_register_value {
                                 reg64: io_message.header.rip + 1,
                             },
@@ -1348,11 +1348,11 @@ mod tests {
         set_registers_64!(vcpu, &arr_reg_name_value).unwrap();
         let mut get_regs: [hv_register_assoc; 2] = [
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RIP as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RIP,
                 ..Default::default()
             },
             hv_register_assoc {
-                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS as u32,
+                name: hv_x64_register_name_HV_X64_REGISTER_RFLAGS,
                 ..Default::default()
             },
         ];

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -217,9 +217,9 @@ impl VmFd {
     /// interrupts from userland.
     fn irqfd(&self, fd: RawFd, resamplefd: RawFd, gsi: u32, flags: u32) -> Result<()> {
         let irqfd_arg = mshv_irqfd {
-            fd: fd as i32,
+            fd,
             flags,
-            resamplefd: resamplefd as i32,
+            resamplefd,
             gsi,
         };
 
@@ -536,7 +536,7 @@ impl VmFd {
             vec![hv_gpa_page_access_state { as_uint8: 0 }; nr_pfns as usize];
         let mut gpa_pages_access_state: mshv_get_gpa_pages_access_state =
             mshv_get_gpa_pages_access_state {
-                count: nr_pfns as u32,
+                count: nr_pfns,
                 hv_gpa_page_number: base_pfn,
                 flags,
                 states: states.as_mut_ptr(),


### PR DESCRIPTION
Allow that for generated code and remove all unnecessary casts in other places.

Signed-off-by: Wei Liu <liuwe@microsoft.com>

### Summary of the PR

The recent changes to bindings.rs changed some types from Rust enum to integer. That caused this issue.

It is surprising the previous CI run didn't catch this.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
