### PR TITLE
mshv: Regenerate bindings to fix isolation props

### DIFF
--- a/mshv-bindings/src/bindings.rs
+++ b/mshv-bindings/src/bindings.rs
@@ -2758,13 +2758,12 @@ impl Default for hv_partition_processor_xsave_features {
 pub struct hv_partition_creation_properties {
     pub disabled_processor_features: hv_partition_processor_features,
     pub disabled_processor_xsave_features: hv_partition_processor_xsave_features,
-    pub isolation_properties: hv_partition_isolation_properties,
 }
 #[test]
 fn bindgen_test_layout_hv_partition_creation_properties() {
     assert_eq!(
         ::std::mem::size_of::<hv_partition_creation_properties>(),
-        32usize,
+        24usize,
         concat!("Size of: ", stringify!(hv_partition_creation_properties))
     );
     assert_eq!(
@@ -2810,23 +2809,6 @@ fn bindgen_test_layout_hv_partition_creation_properties() {
         );
     }
     test_field_disabled_processor_xsave_features();
-    fn test_field_isolation_properties() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<hv_partition_creation_properties>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).isolation_properties) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(hv_partition_creation_properties),
-                "::",
-                stringify!(isolation_properties)
-            )
-        );
-    }
-    test_field_isolation_properties();
 }
 impl Default for hv_partition_creation_properties {
     fn default() -> Self {
@@ -12262,6 +12244,7 @@ pub const hv_message_type_HVMSG_HYPERCALL_INTERCEPT: hv_message_type = 214748372
 pub const hv_message_type_HVMSG_SYNIC_EVENT_INTERCEPT: hv_message_type = 2147483744;
 pub const hv_message_type_HVMSG_SYNIC_SINT_INTERCEPT: hv_message_type = 2147483745;
 pub const hv_message_type_HVMSG_SYNIC_SINT_DELIVERABLE: hv_message_type = 2147483746;
+pub const hv_message_type_HVMSG_ASYNC_CALL_COMPLETION: hv_message_type = 2147483760;
 pub const hv_message_type_HVMSG_SCHEDULER_VP_SIGNAL_BITSET: hv_message_type = 2147483904;
 pub const hv_message_type_HVMSG_SCHEDULER_VP_SIGNAL_PAIR: hv_message_type = 2147483905;
 pub const hv_message_type_HVMSG_X64_IO_PORT_INTERCEPT: hv_message_type = 2147549184;
@@ -13825,6 +13808,7 @@ pub struct mshv_create_partition {
     pub flags: __u64,
     pub partition_creation_properties: hv_partition_creation_properties,
     pub synthetic_processor_features: hv_partition_synthetic_processor_features,
+    pub isolation_properties: hv_partition_isolation_properties,
 }
 #[test]
 fn bindgen_test_layout_mshv_create_partition() {
@@ -13879,7 +13863,7 @@ fn bindgen_test_layout_mshv_create_partition() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).synthetic_processor_features) as usize - ptr as usize
             },
-            40usize,
+            32usize,
             concat!(
                 "Offset of field: ",
                 stringify!(mshv_create_partition),
@@ -13889,6 +13873,23 @@ fn bindgen_test_layout_mshv_create_partition() {
         );
     }
     test_field_synthetic_processor_features();
+    fn test_field_isolation_properties() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<mshv_create_partition>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).isolation_properties) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(mshv_create_partition),
+                "::",
+                stringify!(isolation_properties)
+            )
+        );
+    }
+    test_field_isolation_properties();
 }
 impl Default for mshv_create_partition {
     fn default() -> Self {

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -68,11 +68,11 @@ impl MshvPartitionBuilder {
                     disabled_processor_xsave_features: hv_partition_processor_xsave_features {
                         as_uint64: 0_u64,
                     },
-                    isolation_properties: hv_partition_isolation_properties { as_uint64: 0_u64 },
                 },
                 synthetic_processor_features: hv_partition_synthetic_processor_features {
                     as_uint64: [0; 1],
                 },
+                isolation_properties: hv_partition_isolation_properties { as_uint64: 0_u64 },
                 flags: 0_u64,
             },
         }
@@ -90,7 +90,6 @@ impl MshvPartitionBuilder {
         // so we have to use unsafe here. We trust bindgen to generate the correct accessors.
         unsafe {
             self.mshv_partition
-                .partition_creation_properties
                 .isolation_properties
                 .__bindgen_anon_1
                 .set_isolation_type(val);


### PR DESCRIPTION
### Summary of the PR

Recently we have changed the mshv create partition ioctl definition by moving out isolation property out of partition property. Thus, we should regenrate the bindings to reflect those changes and fix the API accordingly.

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
