### PR TITLE
Expose VmType to the public interface

### DIFF
--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -41,6 +41,18 @@ pub enum VmType {
     Snp,
 }
 
+impl TryFrom<u64> for VmType {
+    type Error = ();
+
+    fn try_from(v: u64) -> std::result::Result<Self, Self::Error> {
+        match v {
+            x if x == VmType::Normal as u64 => Ok(VmType::Normal),
+            x if x == VmType::Snp as u64 => Ok(VmType::Snp),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Helper structure for disabling datamatch.
 ///
 /// The structure can be used as a parameter to

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -33,13 +33,11 @@ pub enum IoEventAddress {
 }
 
 /// VMType represents the type of VM.
-///
-/// Currently we support two different variants:
-/// - AMD's SEV-SNP
-/// - Normal VM with no support for confidential computing
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Copy)]
 pub enum VmType {
+    /// Normal VM with no support for confidential computing
     Normal,
+    /// AMD's SEV-SNP
     Snp,
 }
 

--- a/mshv-ioctls/src/lib.rs
+++ b/mshv-ioctls/src/lib.rs
@@ -208,6 +208,7 @@ pub use ioctls::vm::InterruptRequest;
 pub use ioctls::vm::IoEventAddress;
 pub use ioctls::vm::NoDatamatch;
 pub use ioctls::vm::VmFd;
+pub use ioctls::vm::VmType;
 
 #[macro_use]
 mod mshv_ioctls;


### PR DESCRIPTION
### Summary of the PR

VmType is needed by cloud hypervisor when trying to create a VM. Thus, we need to expose it to the public interface along with it also add support to convert u64 to VmType.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
