### PR TITLE
mshv-ioctls: Extend get_cpuid_values interface

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1008,10 +1008,12 @@ impl VcpuFd {
     /// X86 specific call that retrieves the values of the specified CPUID
     /// leaf as observed on the virtual processor.
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-    pub fn get_cpuid_values(&self, eax: u32, ecx: u32) -> Result<[u32; 4]> {
+    pub fn get_cpuid_values(&self, eax: u32, ecx: u32, xfem: u64, xss: u64) -> Result<[u32; 4]> {
         let mut parms = mshv_get_vp_cpuid_values {
             function: eax,
             index: ecx,
+            xfem,
+            xss,
             ..Default::default()
         };
         // SAFETY: we know that our file is a vCPU fd, we know the kernel will only read the
@@ -1437,7 +1439,7 @@ mod tests {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        let res = vcpu.get_cpuid_values(0, 0).unwrap();
+        let res = vcpu.get_cpuid_values(0, 0, 0, 0).unwrap();
         let max_function = res[0];
         assert!(max_function >= 1);
     }


### PR DESCRIPTION
.... to include xfem and xss as input parameters. Those are required when we would be querying the extended cpuid topology leafs.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
