### PR TITLE
mshv-bindings: function to retrieve offloadble features

### DIFF
--- a/mshv-bindings/src/snp.rs
+++ b/mshv-bindings/src/snp.rs
@@ -632,3 +632,29 @@ impl Default for hv_sev_vmgexit_port_info {
         }
     }
 }
+
+///
+/// Get default VMGEXIT offload features supported by
+/// Microsoft Hypervisor.
+///
+pub fn get_default_vmgexit_offload_features() -> hv_sev_vmgexit_offload {
+    let mut offload_feature = hv_sev_vmgexit_offload::default();
+
+    unsafe {
+        offload_feature.__bindgen_anon_1.set_nae_rdtsc(1);
+        offload_feature.__bindgen_anon_1.set_nae_cpuid(1);
+        offload_feature.__bindgen_anon_1.set_nae_rdmsr(1);
+        offload_feature.__bindgen_anon_1.set_nae_wrmsr(1);
+        offload_feature.__bindgen_anon_1.set_nae_vmmcall(1);
+        offload_feature.__bindgen_anon_1.set_nae_wbinvd(1);
+        offload_feature
+            .__bindgen_anon_1
+            .set_nae_snp_page_state_change(1);
+        offload_feature.__bindgen_anon_1.set_msr_cpuid(1);
+        offload_feature
+            .__bindgen_anon_1
+            .set_msr_snp_page_state_change(1);
+    }
+
+    offload_feature
+}


### PR DESCRIPTION

### Summary of the PR

Microsoft Hypervisor supports offloading some VMGEXITnon-atomic events to the hypervisor. VMM can utilize this feature by enabling VMG exit offloads. This patch adds a function that returns current supported features by MSHV.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
