### PR TITLE
mshv-bindings: Unmarshal hv_message to hv_x64_vmgexit_intercept_message

### DIFF
--- a/mshv-bindings/src/unmarshal.rs
+++ b/mshv-bindings/src/unmarshal.rs
@@ -146,4 +146,16 @@ impl hv_message {
             unsafe { std::ptr::read_unaligned(std::ptr::addr_of!(self.u.payload) as *const _) };
         Ok(ret)
     }
+    #[inline]
+    pub fn to_vmg_intercept_info(&self) -> Result<hv_x64_vmgexit_intercept_message> {
+        if self.header.message_type != hv_message_type_HVMSG_X64_SEV_VMGEXIT_INTERCEPT {
+            return Err(errno::Error::new(libc::EINVAL));
+        }
+        // SAFETY: We know at this point the payload is of the correct type. The payload field is
+        // unaligned. We use addr_of! to safely create a pointer, then call read_unaligned for
+        // copying its content out.
+        let ret =
+            unsafe { std::ptr::read_unaligned(std::ptr::addr_of!(self.u.payload) as *const _) };
+        Ok(ret)
+    }
 }


### PR DESCRIPTION
### Summary of the PR

Unmarshal hv_message to hv_x64_vmgexit_intercept_message

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
