### PR TITLE
cpuid: Handle more AMD specific topology leafs

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -999,7 +999,7 @@ impl VcpuFd {
                     subleaf_specific = Some(1);
                     override_arg = None;
                 }
-                0x0000_0001 | 0x8000_0008 => {
+                0x0000_0001 | 0x8000_0000 | 0x8000_0001 | 0x8000_0008 => {
                     subleaf_specific = None;
                     override_arg = Some(1);
                 }


### PR DESCRIPTION
These leafs are relevant for topology, multithreading and other aspects of topology configuration. See AMD Architecture Programmers Manual (Publication #40332) for the single leafs details.

### Summary of the PR

These leafs are relevant for topology, multithreading and other aspects of topology configuration. See AMD Architecture Programmers Manual (Publication #40332) for the single leafs details. Ref 

https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/programmer-references/40332.pdf

