### PR TITLE
mshv-bindings: Rename clippy warning

### DIFF
--- a/mshv-bindings/src/lib.rs
+++ b/mshv-bindings/src/lib.rs
@@ -12,7 +12,7 @@ extern crate vmm_sys_util;
     clippy::missing_safety_doc,
     clippy::useless_transmute,
     clippy::unnecessary_cast,
-    clippy::incorrect_clone_impl_on_copy_type,
+    clippy::non_canonical_clone_impl,
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals


### PR DESCRIPTION
### Summary of the PR

incorrect_clone_impl_on_copy_type is changed to non_canonical_clone_impl. Thus, rename it.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
