### PR TITLE
Clean up unused MSHV_CHECK_EXTENSION and re-defined __IncompleteArrayField

### DIFF
--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -13,56 +13,6 @@ use vmm_sys_util::errno;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
-impl<T> __IncompleteArrayField<T> {
-    #[inline]
-    pub fn new() -> Self {
-        __IncompleteArrayField(::std::marker::PhantomData, [])
-    }
-
-    #[inline]
-    /// # Safety
-    /// Safe Beacuse we know the size of the field.
-    /// Caller needs to make sure lossless conversion
-    pub unsafe fn as_ptr(&self) -> *const T {
-        self as *const __IncompleteArrayField<T> as *const T
-    }
-    #[inline]
-    /// # Safety
-    /// Safe Beacuse we know the size of the field.
-    /// Caller needs to make sure lossless conversion
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        self as *const __IncompleteArrayField<T> as *mut T
-    }
-    #[inline]
-    /// # Safety
-    /// Safe Beacuse we know the size of the field.
-    /// Caller needs to make sure lossless conversion
-    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
-    }
-    #[inline]
-    /// # Safety
-    /// Safe Beacuse we know the size of the field.
-    /// Caller needs to make sure lossless conversion
-    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-    }
-}
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        fmt.write_str("__IncompleteArrayField")
-    }
-}
-impl<T> ::std::clone::Clone for __IncompleteArrayField<T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self::new()
-    }
-}
-
-#[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, AsBytes, FromBytes, FromZeroes)]
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct StandardRegisters {

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -299,19 +299,6 @@ impl Mshv {
         self.create_vm_with_type(VmType::Normal)
     }
 
-    /// Check if MSHV API is stable
-    pub fn check_stable(&self) -> Result<bool> {
-        // Safe because we know `self.hv` is a real MSHV fd as this module is the only one that
-        // creates mshv objects.
-        let cap: u32 = MSHV_CAP_CORE_API_STABLE;
-        // SAFETY: IOCTL call with the correct types.
-        let ret = unsafe { ioctl_with_ref(&self.hv, MSHV_CHECK_EXTENSION(), &cap) };
-        match ret {
-            0 => Ok(false),
-            r if r > 0 => Ok(true),
-            _ => Err(errno::Error::last()),
-        }
-    }
     /// X86 specific call to get list of supported MSRS
     pub fn get_msr_index_list(&self) -> Result<MsrList> {
         /* return all the MSRs we currently support */

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 use mshv_bindings::*;
-ioctl_iow_nr!(MSHV_CHECK_EXTENSION, MSHV_IOCTL, 0x00, u32);
 ioctl_iow_nr!(MSHV_CREATE_VP, MSHV_IOCTL, 0x04, mshv_create_vp);
 ioctl_iowr_nr!(MSHV_GET_VP_REGISTERS, MSHV_IOCTL, 0x05, mshv_vp_registers);
 ioctl_iow_nr!(MSHV_SET_VP_REGISTERS, MSHV_IOCTL, 0x06, mshv_vp_registers);


### PR DESCRIPTION
- `MSHV_CHECK_EXTENSION` will soon be replaced, so remove it here ahead of time. The associated function `check_stable()` is not used in any case.
- An upcoming PR uses `__IncompleteArrayField` and I was getting a compiler warning about it being defined twice - it should only be defined in `bindings.rs` AFAIK.