### PR TITLE
Introduce generic hypercall ioctl

### DIFF
--- a/mshv-bindings/src/hvcall.rs
+++ b/mshv-bindings/src/hvcall.rs
@@ -1,0 +1,186 @@
+// Copyright © 2024, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+
+use crate::bindings::*;
+use std::mem::size_of;
+use std::vec::Vec;
+
+/// This file contains helper functions for the MSHV_ROOT_HVCALL ioctl.
+/// MSHV_ROOT_HVCALL is basically a 'passthrough' hypercall. The kernel makes a
+/// hypercall on behalf of the VMM without interpreting the arguments or result
+/// or changing any state in the kernel.
+
+/// RepInput<T> wraps a buffer containing the input for a "rep"[1] hypercall.
+/// Rep hypercalls have rep-eated data, i.e. a variable length array as part of
+/// the input structure e.g.:
+/// ```
+/// use mshv_bindings::bindings::*;
+/// #[repr(C, packed)]
+/// struct hv_input_foo {
+///    some_field: __u64,
+///    variable_array_field: __IncompleteArrayField<__u64>,
+/// }
+/// ```
+/// The struct cannot be used as-is because it can't store anything in the
+/// __IncompleteArrayField<T> field.
+///
+/// RepInput<T> abstracts a rep hypercall input by wrapping a Vec<T>, where T
+/// is the hv_input_* struct type. The buffer backing the Vec<T> has enough
+/// space to store both the hv_input_* struct (at index 0), and the rep data
+/// immediately following it.
+///
+/// Note also that the length of the variable length array field is not stored in
+/// this struct. Rather, it is passed to the hypercall in the 'rep count' field
+/// of the hypercall args (mshv_root_hvcall.reps). RepInput<T> stores this count,
+/// along with the size of the entire input data.
+///
+/// RepInput<T> is intended to be created with make_rep_input!() and used with
+/// make_rep_args!() below.
+///
+/// [1] HyperV TLFS describing the hypercall interface and rep hypercalls:
+///   https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercall-interface
+///
+pub struct RepInput<T> {
+    vec: Vec<T>,
+    size: usize,
+    rep_count: usize,
+}
+impl<T> RepInput<T> {
+    /// Create a RepInput<T> for a rep hypercall
+    ///
+    /// # Arguments
+    ///
+    /// * `vec` - Vec<T> Created via vec_with_array_field(). T is hv_input_* struct
+    /// * `size` - Size of the hypercall input, including the rep data
+    /// * `rep_count` - number of reps
+    pub fn new(vec: Vec<T>, size: usize, rep_count: usize) -> Self {
+        Self {
+            vec,
+            size,
+            rep_count,
+        }
+    }
+    pub fn as_mut_struct_ref(&mut self) -> &mut T {
+        &mut self.vec[0]
+    }
+    pub fn as_struct_ptr(&self) -> *const T {
+        &self.vec[0]
+    }
+    pub fn rep_count(&self) -> usize {
+        self.rep_count
+    }
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+/// Make `Vec<T>` with at least enough space for `count` + 1 entries of
+/// `entry_size`, where `entry_size` != size_of::<T>()
+/// The first element of the Vec will hold the T data, and the rest will hold
+/// elements of size `entry_size` (note the Vec cannot be used normally to get
+/// at these)
+pub fn vec_with_array_field<T: Default>(t: T, entry_size: usize, count: usize) -> Vec<T> {
+    let element_space = count * entry_size;
+    let vec_size_bytes = size_of::<T>() + element_space;
+    let rounded_size = (vec_size_bytes + size_of::<T>() - 1) / size_of::<T>();
+    let mut v = Vec::with_capacity(rounded_size);
+    v.resize_with(rounded_size, T::default);
+    v[0] = t;
+    v
+}
+
+/// Utility for casting __IncompleteArrayField<T> as the interior type
+pub fn arr_field_as_entry_ptr_mut<T>(ptr: *mut __IncompleteArrayField<T>) -> *mut T {
+    ptr as *mut T
+}
+
+/// Utility for getting the interior type of a __IncompleteArrayField<T>
+/// Note we must use a raw pointer rather than a reference here, because the
+/// field itself may be unaligned due to the struct being packed
+pub fn arr_field_entry_size<T>(_: *const __IncompleteArrayField<T>) -> usize {
+    size_of::<T>()
+}
+
+/// Assemble a RepInput<T> from a hypercall input struct and an array of rep data
+/// Arguments:
+///     1. The hv_input_* struct with the input data
+///     2. Name of the __IncompleteArrayField<T> in the struct
+///     3. An array or slice containing the rep data
+#[macro_export]
+macro_rules! make_rep_input {
+    ($struct_expr:expr, $field_ident:ident, $arr_expr:expr) => {{
+        let s = $struct_expr;
+        let a = $arr_expr;
+        let el_size = arr_field_entry_size(std::ptr::addr_of!(s.$field_ident));
+        let struct_size = std::mem::size_of_val(&s);
+        let mut vec = vec_with_array_field(s, el_size, a.len());
+        // SAFETY: we know the vector is large enough to hold the data
+        let ptr = arr_field_as_entry_ptr_mut(std::ptr::addr_of_mut!(vec[0].$field_ident));
+        for (i, el) in a.iter().enumerate() {
+            unsafe {
+                let mut p = ptr.add(i);
+                p.write_unaligned(*el);
+            };
+        }
+        RepInput::new(vec, struct_size + el_size * a.len(), a.len())
+    }};
+}
+
+/// Create a mshv_root_hvcall populated with rep hypercall parameters
+/// Arguments:
+///     1. hypercall code
+///     2. RepInput<T> structure, where T is hv_input_*. See make_rep_input!()
+///     3. Slice of the correct type for output data (optional)
+#[macro_export]
+macro_rules! make_rep_args {
+    ($code_expr:expr, $input_ident:ident, $output_slice_ident:ident) => {{
+        mshv_root_hvcall {
+            code: $code_expr as u16,
+            reps: $input_ident.rep_count() as u16,
+            in_sz: $input_ident.size() as u16,
+            out_sz: (std::mem::size_of_val(&$output_slice_ident[0]) * $output_slice_ident.len())
+                as u16,
+            in_ptr: $input_ident.as_struct_ptr() as u64,
+            out_ptr: std::ptr::addr_of_mut!($output_slice_ident[0]) as u64,
+            ..Default::default()
+        }
+    }};
+    ($code_expr:expr, $input_ident:ident) => {{
+        mshv_root_hvcall {
+            code: $code_expr as u16,
+            reps: $input_ident.rep_count() as u16,
+            in_sz: $input_ident.size() as u16,
+            in_ptr: $input_ident.as_struct_ptr() as u64,
+            ..Default::default()
+        }
+    }};
+}
+
+/// Create a mshv_root_hvcall populated with hypercall parameters
+/// Arguments:
+///     1. hypercall code
+///     2. hv_input_* structure
+///     3. hv_output_* structure (optional)
+#[macro_export]
+macro_rules! make_args {
+    ($code_expr:expr, $input_ident:ident, $output_ident:ident) => {{
+        mshv_root_hvcall {
+            code: $code_expr as u16,
+            in_sz: std::mem::size_of_val(&$input_ident) as u16,
+            out_sz: std::mem::size_of_val(&$output_ident) as u16,
+            in_ptr: std::ptr::addr_of!($input_ident) as u64,
+            out_ptr: std::ptr::addr_of!($output_ident) as u64,
+            ..Default::default()
+        }
+    }};
+    ($code_expr:expr, $input_ident:ident) => {{
+        mshv_root_hvcall {
+            code: $code_expr as u16,
+            in_sz: std::mem::size_of_val(&$input_ident) as u16,
+            in_ptr: std::ptr::addr_of!($input_ident) as u64,
+            ..Default::default()
+        }
+    }};
+}

--- a/mshv-bindings/src/lib.rs
+++ b/mshv-bindings/src/lib.rs
@@ -13,10 +13,13 @@ mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use self::x86_64::*;
 
-pub mod hvdef;
-pub use hvdef::*;
-
 #[cfg(target_arch = "aarch64")]
 mod arm64;
 #[cfg(target_arch = "aarch64")]
 pub use self::arm64::*;
+
+pub mod hvdef;
+pub use hvdef::*;
+
+pub mod hvcall;
+pub use hvcall::*;

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -43,6 +43,7 @@ macro_rules! set_registers_64 {
 #[derive(Debug)]
 /// Wrapper over Mshv vCPU ioctls.
 pub struct VcpuFd {
+    index: u32,
     vcpu: File,
 }
 
@@ -51,8 +52,8 @@ pub struct VcpuFd {
 /// This should not be exported as a public function because the preferred way is to use
 /// `create_vcpu` from `VmFd`. The function cannot be part of the `VcpuFd` implementation because
 /// then it would be exported with the public `VcpuFd` interface.
-pub fn new_vcpu(vcpu: File) -> VcpuFd {
-    VcpuFd { vcpu }
+pub fn new_vcpu(index: u32, vcpu: File) -> VcpuFd {
+    VcpuFd { index, vcpu }
 }
 
 impl AsRawFd for VcpuFd {

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
-use crate::ioctls::Result;
+use crate::ioctls::{MshvError, Result};
 use crate::mshv_ioctls::*;
 use mshv_bindings::*;
 use std::convert::TryFrom;
@@ -1114,6 +1114,17 @@ impl VcpuFd {
             self.set_vp_state_ioctl(&vp_state)?;
         }
         Ok(())
+    }
+
+    /// Execute a hypercall for this vp
+    pub fn hvcall(&self, args: &mut mshv_root_hvcall) -> Result<()> {
+        // SAFETY: IOCTL with correct types
+        let ret = unsafe { ioctl_with_ref(self, MSHV_ROOT_HVCALL(), args) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(MshvError::from_hvcall(errno::Error::last(), *args))
+        }
     }
 }
 

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -784,7 +784,7 @@ mod tests {
             intercept_type: hv_intercept_type_HV_INTERCEPT_TYPE_X64_CPUID,
             intercept_parameter: hv_intercept_parameters { cpuid_index: 0x100 },
         };
-        vm.install_intercept(intercept_args).unwrap();
+        assert!(vm.install_intercept(intercept_args).is_ok());
     }
     #[test]
     fn test_setting_immutable_partition_property() {

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -202,7 +202,7 @@ impl VmFd {
         // SAFETY: we're sure vcpu_fd is valid.
         let vcpu = unsafe { File::from_raw_fd(vcpu_fd) };
 
-        Ok(new_vcpu(vcpu))
+        Ok(new_vcpu(id as u32, vcpu))
     }
     /// Inject an interrupt into the guest..
     pub fn request_virtual_interrupt(&self, request: &InterruptRequest) -> Result<()> {

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -134,3 +134,5 @@ ioctl_iow_nr!(
     0x34,
     mshv_sev_snp_ap_create
 );
+
+ioctl_iowr_nr!(MSHV_ROOT_HVCALL, MSHV_IOCTL, 0x35, mshv_root_hvcall);


### PR DESCRIPTION
### Summary of the PR

This PR introduces the generic hypercall IOCTL - MSHV_ROOT_HVCALL.
It can be used on both the partition and vp fds.

This IOCTL reduces the number of IOCTLs needed in the kernel interface, reducing maintenance and making the kernel code more upstreamable.

This PR introduces the IOCTL and implements some use-cases for it, but it doesn't replace the default implementations so it won't affect downstream.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
