### PR TITLE
Enable x2apic for regular guests

### DIFF
--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -267,6 +267,7 @@ impl Mshv {
     pub fn create_vm_with_type(&self, vm_type: VmType) -> Result<VmFd> {
         let mut mshv_builder = MshvPartitionBuilder::new()
             .set_partition_creation_flag(HV_PARTITION_CREATION_FLAG_LAPIC_ENABLED as u64)
+            .set_partition_creation_flag(HV_PARTITION_CREATION_FLAG_X2APIC_CAPABLE as u64)
             .set_synthetic_processor_feature(SyntheticProcessorFeature::HypervisorPresent)
             .set_synthetic_processor_feature(SyntheticProcessorFeature::Hv1)
             .set_synthetic_processor_feature(
@@ -285,7 +286,6 @@ impl Mshv {
 
         if vm_type == VmType::Snp {
             mshv_builder = mshv_builder
-                .set_partition_creation_flag(HV_PARTITION_CREATION_FLAG_X2APIC_CAPABLE as u64)
                 .set_isolation_type(HV_PARTITION_ISOLATION_TYPE_SNP as u64)
                 .set_shared_gpa_boundary_page_number(0_u64);
         }

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -79,7 +79,7 @@ impl MshvPartitionBuilder {
     }
 
     /// Updates partition flags
-    pub fn set_partiton_creation_flag(mut self, flag: u64) -> MshvPartitionBuilder {
+    pub fn set_partition_creation_flag(mut self, flag: u64) -> MshvPartitionBuilder {
         self.mshv_partition.flags |= flag;
         self
     }
@@ -266,7 +266,7 @@ impl Mshv {
     /// Helper function to creates a VM fd using the MSHV fd with provided configuration.
     pub fn create_vm_with_type(&self, vm_type: VmType) -> Result<VmFd> {
         let mut mshv_builder = MshvPartitionBuilder::new()
-            .set_partiton_creation_flag(HV_PARTITION_CREATION_FLAG_LAPIC_ENABLED as u64)
+            .set_partition_creation_flag(HV_PARTITION_CREATION_FLAG_LAPIC_ENABLED as u64)
             .set_synthetic_processor_feature(SyntheticProcessorFeature::HypervisorPresent)
             .set_synthetic_processor_feature(SyntheticProcessorFeature::Hv1)
             .set_synthetic_processor_feature(
@@ -285,7 +285,7 @@ impl Mshv {
 
         if vm_type == VmType::Snp {
             mshv_builder = mshv_builder
-                .set_partiton_creation_flag(HV_PARTITION_CREATION_FLAG_X2APIC_CAPABLE as u64)
+                .set_partition_creation_flag(HV_PARTITION_CREATION_FLAG_X2APIC_CAPABLE as u64)
                 .set_isolation_type(HV_PARTITION_ISOLATION_TYPE_SNP as u64)
                 .set_shared_gpa_boundary_page_number(0_u64);
         }


### PR DESCRIPTION
### Summary of the PR

This is needed to influence guest Linux to use physical address mode for MSIs (which it does by default when x2apic is enabled), which allows to support virtual interrupt injections in MSHV driver and thus improve overall VirtIO throughput.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
