### PR TITLE
Export ioctl numbers

### DIFF
--- a/mshv-ioctls/src/lib.rs
+++ b/mshv-ioctls/src/lib.rs
@@ -212,5 +212,7 @@ pub use ioctls::vm::VmType;
 
 #[macro_use]
 mod mshv_ioctls;
+pub use mshv_ioctls::*;
+
 #[macro_use]
 extern crate vmm_sys_util;

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
+#![allow(missing_docs)]
+
 use mshv_bindings::*;
 ioctl_iow_nr!(MSHV_CREATE_VP, MSHV_IOCTL, 0x04, mshv_create_vp);
 ioctl_iowr_nr!(MSHV_GET_VP_REGISTERS, MSHV_IOCTL, 0x05, mshv_vp_registers);

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -5,6 +5,8 @@
 #![allow(missing_docs)]
 
 use mshv_bindings::*;
+
+ioctl_iow_nr!(MSHV_GET_VERSION_INFO, MSHV_IOCTL, 0x00, mshv_version_info);
 ioctl_iow_nr!(MSHV_CREATE_VP, MSHV_IOCTL, 0x04, mshv_create_vp);
 ioctl_iowr_nr!(MSHV_GET_VP_REGISTERS, MSHV_IOCTL, 0x05, mshv_vp_registers);
 ioctl_iow_nr!(MSHV_SET_VP_REGISTERS, MSHV_IOCTL, 0x06, mshv_vp_registers);


### PR DESCRIPTION
### Summary of the PR

In Cloud Hypervisor, the seccomp rules have hardcoded IOCTL numbers from the various bindings crates.
It would be nice to just get the IOCTL numbers from the crate itself. At the very least, it saves the time of having to compute or print out the IOCTL numbers manually when changing them or adding new ones.

Also add the MSHV_GET_VERSION_INFO IOCTL number.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
