### PR TITLE
mshv-bindings: Turn off default features for num_enum

### DIFF
--- a/mshv-bindings/Cargo.toml
+++ b/mshv-bindings/Cargo.toml
@@ -11,7 +11,7 @@ with-serde = ["serde", "serde_derive"]
 
 [dependencies]
 libc = ">=0.2.39"
-num_enum = "0.7"
+num_enum = { version = "0.7", default-features = false }
 serde = { version = ">=1.0.27", optional = true }
 serde_derive = { version = ">=1.0.27", optional = true }
 vmm-sys-util = ">=0.12.1"


### PR DESCRIPTION
### Summary of the PR

num_enum with default features turned breaks the compilation of rust-vmm/vfio crate.

error: package `toml_edit v0.21.1` cannot be built because it requires rustc 1.69 or newer, while the currently active rustc version is 1.67.1 Either upgrade to rustc 1.69 or newer, or use
cargo update -p toml_edit@0.21.1 --precise ver
where `ver` is the latest version of `toml_edit` supporting rustc 1.67.1 🚨 Error: The command exited with status 101

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
