### PR TITLE
mshv-bindings: Derive constant instead of hard-coding

### DIFF
--- a/mshv-bindings/src/regs.rs
+++ b/mshv-bindings/src/regs.rs
@@ -681,13 +681,30 @@ pub struct MiscRegs {
     pub hypercall: u64,
 }
 
+const fn initialize_comp_sizes() -> [usize; MSHV_VP_STATE_COUNT as usize] {
+    let mut vp_state_comp_size = [0; MSHV_VP_STATE_COUNT as usize];
+
+    vp_state_comp_size[MSHV_VP_STATE_LAPIC as usize] = std::mem::size_of::<LapicState>();
+    vp_state_comp_size[MSHV_VP_STATE_XSAVE as usize] = std::mem::size_of::<XSave>();
+    vp_state_comp_size[MSHV_VP_STATE_SIMP as usize] = HV_PAGE_SIZE; // Assuming SIMP page is
+                                                                    // allocated by the Hypervisor
+                                                                    // which is of PAGE_SIZE
+    vp_state_comp_size[MSHV_VP_STATE_SIEFP as usize] = HV_PAGE_SIZE; // Assuming SIEFP page is
+                                                                     // allocated by the Hypervisor
+                                                                     // which is of PAGE_SIZE
+    vp_state_comp_size[MSHV_VP_STATE_SYNTHETIC_TIMERS as usize] =
+        std::mem::size_of::<hv_synthetic_timers_state>();
+
+    vp_state_comp_size
+}
+
 // Total size: 13512 bytes
 // 1. MSHV_VP_STATE_LAPIC, Size: 1024 bytes;
 // 2. MSHV_VP_STATE_XSAVE, Size: 4096 bytes;
 // 3. MSHV_VP_STATE_SIMP, Size: 4096 bytes;
 // 4. MSHV_VP_STATE_SIEFP, Size: 4096 bytes;
 // 5. MSHV_VP_STATE_SYNTHETIC_TIMERS, Size: 200 bytes;
-const VP_STATE_COMP_SIZES: [usize; 5] = [0x400, 0x1000, 0x1000, 0x1000, 0xC8];
+const VP_STATE_COMP_SIZES: [usize; MSHV_VP_STATE_COUNT as usize] = initialize_comp_sizes();
 
 pub const VP_STATE_COMPONENTS_BUFFER_SIZE: usize = VP_STATE_COMP_SIZES
     [MSHV_VP_STATE_LAPIC as usize]


### PR DESCRIPTION
### Summary of the PR

Constants like LAPIC_STATE size could be derived by calling size_of on the struct LapicState. In the similar fashion, other values can also be derived. Use a const function to intialize the various component sizes.


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
