### PR TITLE
Make test suite pass under Tree Borrows

### DIFF
--- a/mshv-bindings/src/x86_64/snp.rs
+++ b/mshv-bindings/src/x86_64/snp.rs
@@ -1173,7 +1173,7 @@ mod tests {
     fn test_svm_macro() {
         let mut st: svm_ghcb_base = svm_ghcb_base::default();
         println!("{}", std::mem::size_of::<svm_ghcb_base>());
-        let pptr: *mut svm_ghcb_base = &mut st;
+        let pptr: *mut svm_ghcb_base = core::ptr::addr_of_mut!(st);
         set_svm_field_u64_ptr!(pptr, cpl, 100);
         let mut val = st.cpl as u64;
         let mut bitmap = st.valid_bitmap;


### PR DESCRIPTION
Tree Borrows is a proposed replacement for Stacked Borrows, which is more permissive in general, but introduces new UB in edge cases. This commit fixes one such edge case.

### Summary of the PR

[Tree Borrows](https://www.ralfj.de/blog/2023/06/02/tree-borrows.html) is a proposed replacement for Stacked Borrows, or at least an alternative aliasing model. It tries to fix some of Stacked Borrows shortcomings, and is in general more relaxed. There are however some areas where it has more UB than Stacked Borrows, and this crate seems to exhibit one of these examples. The fix is very small, and the problem arose because the code unnecessarily created a reference where none should have been created.
I did however not read the entire code to find if this is the only place this pattern occurs in; though it is the only place within the test suite, apparently.

Checking for compatibility with Tree Borrows requires setting `MIRIFLAGS="-Zmiri-tree-borrows"` as an environment variable. Be aware that this is currently quite slow, we're working on making it faster. 

### Requirements

Most of these don't apply, but I hope the commit message/text is satisfactory.

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
