### PR TITLE
mshv-bindings: Add support for unmarshaling memory intercept

### DIFF
--- a/mshv-bindings/src/arm64/mod.rs
+++ b/mshv-bindings/src/arm64/mod.rs
@@ -18,3 +18,4 @@ pub mod bindings;
 pub use bindings::*;
 pub mod regs;
 pub use regs::*;
+mod unmarshal;

--- a/mshv-bindings/src/arm64/unmarshal.rs
+++ b/mshv-bindings/src/arm64/unmarshal.rs
@@ -1,0 +1,24 @@
+// Copyright © 2025, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+use crate::bindings::*;
+use vmm_sys_util::errno;
+
+type Result<T> = std::result::Result<T, errno::Error>;
+// hv_message implementation for unmarshaling payload
+impl hv_message {
+    #[inline]
+    pub fn to_memory_info(&self) -> Result<hv_arm64_memory_intercept_message> {
+        if self.header.message_type != hv_message_type_HVMSG_GPA_INTERCEPT
+            && self.header.message_type != hv_message_type_HVMSG_UNMAPPED_GPA
+            && self.header.message_type != hv_message_type_HVMSG_UNACCEPTED_GPA
+        {
+            return Err(errno::Error::new(libc::EINVAL));
+        }
+
+        let ret =
+            unsafe { std::ptr::read_unaligned(std::ptr::addr_of!(self.u.payload) as *const _) };
+        Ok(ret)
+    }
+}


### PR DESCRIPTION
.... message. This would be used to be CLH while handling VMEXITs for ARM64 guests.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
