### PR TITLE
mshv-ioctls: Implement get/set reg for aarch64

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -123,7 +123,6 @@ impl VcpuFd {
     }
 
     /// Get the register values by providing an array of register names
-    #[cfg(not(target_arch = "aarch64"))]
     pub fn get_reg(&self, reg_names: &mut [hv_register_assoc]) -> Result<()> {
         //TODO: Error if input register len is zero
         let mut mshv_vp_register_args = mshv_vp_registers {
@@ -178,7 +177,6 @@ impl VcpuFd {
         Ok(())
     }
     /// Set vcpu register values by providing an array of register assocs
-    #[cfg(not(target_arch = "aarch64"))]
     pub fn set_reg(&self, regs: &[hv_register_assoc]) -> Result<()> {
         let hv_vp_register_args = mshv_vp_registers {
             count: regs.len() as i32,


### PR DESCRIPTION
Get/Set reg interface works the same way on ARM64 as it works on x86. So there is no point of conditional compilation on just x86 architecture.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
