### PR TITLE
mshv-ioctls: Don't initialize partition after creation

### DIFF
--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -191,8 +191,6 @@ impl Mshv {
             make_synthetic_features_mask(),
         )?;
 
-        vm.initialize()?;
-
         Ok(vm)
     }
 


### PR DESCRIPTION
### Summary of the PR

Instead, we should let VMM decide when it wants to initialize the partition. For example, for an ARM64 guest VMM needs to setup GIC params before the partition is initialized. Because the GIC params are early partition properties which can only be set before the partition is initialized.

In general, since MSHV considers a distinction between partition creation vs partition initialization, we should reflect the same in our APIs and not club together into a single function.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
