### PR TITLE
Nudasnev/hvcall ioctls

### DIFF
--- a/mshv-bindings/src/hvcall.rs
+++ b/mshv-bindings/src/hvcall.rs
@@ -173,7 +173,7 @@ macro_rules! make_args {
             in_sz: std::mem::size_of_val(&$input_ident) as u16,
             out_sz: std::mem::size_of_val(&$output_ident) as u16,
             in_ptr: std::ptr::addr_of!($input_ident) as u64,
-            out_ptr: std::ptr::addr_of!($output_ident) as u64,
+            out_ptr: std::ptr::addr_of_mut!($output_ident) as u64,
             ..Default::default()
         }
     }};

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1448,7 +1448,7 @@ impl VcpuFd {
             gva_page: gva >> HV_HYP_PAGE_SHIFT,
             ..Default::default() // NOTE: kernel will populate partition_id field
         };
-        let output = hv_output_translate_virtual_address {
+        let mut output = hv_output_translate_virtual_address {
             ..Default::default()
         };
         let mut args = make_args!(HVCALL_TRANSLATE_VIRTUAL_ADDRESS, input, output);

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -2560,6 +2560,7 @@ mod tests {
         assert!(max_function >= 1);
         let res_1 = vcpu.hvcall_get_cpuid_values(0, 0, 0, 0).unwrap();
         assert!(res_1[0] >= 1);
+        assert!(res_0[0] == res_1[0]);
     }
 
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
### Summary of the PR

Add `hvcall_` versions for most of the remaining deprecated ioctls, so they use the generic `MSHV_ROOT_HVCALL` ioctl instead.
Add tests for them too. No functional change expected.