### PR TITLE
mshv-ioctls: property value is 64 bits

### DIFF
--- a/mshv-bindings/src/arm64/bindings.rs
+++ b/mshv-bindings/src/arm64/bindings.rs
@@ -13535,57 +13535,6 @@ impl Default for mshv_assert_interrupt {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
-pub struct mshv_partition_property {
-    pub property_code: hv_partition_property_code,
-    pub property_value: __u64,
-}
-#[test]
-fn bindgen_test_layout_mshv_partition_property() {
-    const UNINIT: ::std::mem::MaybeUninit<mshv_partition_property> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<mshv_partition_property>(),
-        16usize,
-        concat!("Size of: ", stringify!(mshv_partition_property))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<mshv_partition_property>(),
-        8usize,
-        concat!("Alignment of ", stringify!(mshv_partition_property))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).property_code) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(mshv_partition_property),
-            "::",
-            stringify!(property_code)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).property_value) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(mshv_partition_property),
-            "::",
-            stringify!(property_value)
-        )
-    );
-}
-impl Default for mshv_partition_property {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct mshv_translate_gva {
     pub gva: __u64,
     pub flags: __u64,
@@ -14340,6 +14289,48 @@ fn bindgen_test_layout_mshv_create_partition_v2() {
             stringify!(mshv_create_partition_v2),
             "::",
             stringify!(pt_rsvd1)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub struct mshv_partition_property {
+    pub property_code: __u64,
+    pub property_value: __u64,
+}
+#[test]
+fn bindgen_test_layout_mshv_partition_property() {
+    const UNINIT: ::std::mem::MaybeUninit<mshv_partition_property> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<mshv_partition_property>(),
+        16usize,
+        concat!("Size of: ", stringify!(mshv_partition_property))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<mshv_partition_property>(),
+        8usize,
+        concat!("Alignment of ", stringify!(mshv_partition_property))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).property_code) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mshv_partition_property),
+            "::",
+            stringify!(property_code)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).property_value) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mshv_partition_property),
+            "::",
+            stringify!(property_value)
         )
     );
 }

--- a/mshv-bindings/src/x86_64/bindings.rs
+++ b/mshv-bindings/src/x86_64/bindings.rs
@@ -6568,6 +6568,15 @@ pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GICD_BASE_ADDRESS:
     hv_partition_property_code = 327720;
 pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GITS_TRANSLATER_BASE_ADDRESS:
     hv_partition_property_code = 327721;
+pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GIC_LPI_INT_ID_BITS:
+    hv_partition_property_code = 327722;
+pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GIC_PPI_OVERFLOW_INTERRUPT_FROM_CNTV:
+    hv_partition_property_code = 327723;
+pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GIC_PPI_OVERFLOW_INTERRUPT_FROM_CNTP:
+    hv_partition_property_code = 327724;
+pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GIC_PPI_PERFORMANCE_MONITORS_INTERRUPT : hv_partition_property_code = 327725 ;
+pub const hv_partition_property_code_HV_PARTITION_PROPERTY_GIC_PPI_PMBIRQ:
+    hv_partition_property_code = 327726;
 pub const hv_partition_property_code_HV_PARTITION_PROPERTY_PROCESSOR_VENDOR:
     hv_partition_property_code = 393216;
 pub const hv_partition_property_code_HV_PARTITION_PROPERTY_PROCESSOR_FEATURES_DEPRECATED:
@@ -20374,31 +20383,6 @@ impl Default for mshv_assert_interrupt {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
-pub struct mshv_partition_property {
-    pub property_code: hv_partition_property_code,
-    pub property_value: __u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of mshv_partition_property"][::std::mem::size_of::<mshv_partition_property>() - 16usize];
-    ["Alignment of mshv_partition_property"]
-        [::std::mem::align_of::<mshv_partition_property>() - 8usize];
-    ["Offset of field: mshv_partition_property::property_code"]
-        [::std::mem::offset_of!(mshv_partition_property, property_code) - 0usize];
-    ["Offset of field: mshv_partition_property::property_value"]
-        [::std::mem::offset_of!(mshv_partition_property, property_value) - 8usize];
-};
-impl Default for mshv_partition_property {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct mshv_translate_gva {
     pub gva: __u64,
     pub flags: __u64,
@@ -20721,6 +20705,22 @@ const _: () = {
         [::std::mem::offset_of!(mshv_create_partition_v2, pt_rsvd1) - 40usize];
     ["Offset of field: mshv_create_partition_v2::pt_disabled_xsave"]
         [::std::mem::offset_of!(mshv_create_partition_v2, pt_disabled_xsave) - 56usize];
+};
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub struct mshv_partition_property {
+    pub property_code: __u64,
+    pub property_value: __u64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of mshv_partition_property"][::std::mem::size_of::<mshv_partition_property>() - 16usize];
+    ["Alignment of mshv_partition_property"]
+        [::std::mem::align_of::<mshv_partition_property>() - 8usize];
+    ["Offset of field: mshv_partition_property::property_code"]
+        [::std::mem::offset_of!(mshv_partition_property, property_code) - 0usize];
+    ["Offset of field: mshv_partition_property::property_value"]
+        [::std::mem::offset_of!(mshv_partition_property, property_value) - 8usize];
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::os::raw::c_char;
 use std::os::unix::io::{FromRawFd, RawFd};
 use vmm_sys_util::errno;
-use vmm_sys_util::ioctl::ioctl_with_ref;
+use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref};
 
 /// Wrapper over MSHV system ioctls.
 #[derive(Debug)]
@@ -74,12 +74,17 @@ impl Mshv {
     }
 
     /// Retrieve the host partition property given a property code.
-    pub fn get_host_partition_property(&self, property_code: u64) -> Result<i32> {
+    pub fn get_host_partition_property(&self, property_code: u32) -> Result<u64> {
+        let mut property = mshv_partition_property {
+            property_code: property_code as u64,
+            ..Default::default()
+        };
         // SAFETY: IOCTL call with the correct types.
-        let ret =
-            unsafe { ioctl_with_ref(&self.hv, MSHV_GET_HOST_PARTITION_PROPERTY(), &property_code) };
-        if ret >= 0 {
-            Ok(ret)
+        let ret = unsafe {
+            ioctl_with_mut_ref(&self.hv, MSHV_GET_HOST_PARTITION_PROPERTY(), &mut property)
+        };
+        if ret == 0 {
+            Ok(property.property_value)
         } else {
             Err(errno::Error::last().into())
         }
@@ -171,7 +176,7 @@ mod tests {
     fn test_get_host_ipa_limit() {
         let hv = Mshv::new().unwrap();
         let host_ipa_limit = hv.get_host_partition_property(
-            hv_partition_property_code_HV_PARTITION_PROPERTY_PHYSICAL_ADDRESS_WIDTH as u64,
+            hv_partition_property_code_HV_PARTITION_PROPERTY_PHYSICAL_ADDRESS_WIDTH,
         );
         assert!(host_ipa_limit.is_ok());
     }

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -613,7 +613,7 @@ impl VmFd {
     /// For more of the codes, please see the hv_partition_property_code type definitions in the bindings.rs
     pub fn get_partition_property(&self, code: u32) -> Result<u64> {
         let mut property = mshv_partition_property {
-            property_code: code,
+            property_code: code as u64,
             ..Default::default()
         };
         // SAFETY: IOCTL with correct types
@@ -629,7 +629,7 @@ impl VmFd {
     /// Sets a partion property
     pub fn set_partition_property(&self, code: u32, value: u64) -> Result<()> {
         let property: mshv_partition_property = mshv_partition_property {
-            property_code: code,
+            property_code: code as u64,
             property_value: value,
         };
         // SAFETY: IOCTL with correct types

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -13,7 +13,12 @@ ioctl_iow_nr!(
     0x00,
     mshv_create_partition
 );
-ioctl_ior_nr!(MSHV_GET_HOST_PARTITION_PROPERTY, MSHV_IOCTL, 0x01, u64);
+ioctl_iowr_nr!(
+    MSHV_GET_HOST_PARTITION_PROPERTY,
+    MSHV_IOCTL,
+    0x01,
+    mshv_partition_property
+);
 
 // partition fd
 ioctl_io_nr!(MSHV_INITIALIZE_PARTITION, MSHV_IOCTL, 0x00);


### PR DESCRIPTION
Fix get_host_partition_property to return unsigned 64 bits property value.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
