### PR TITLE
scripts: fix vfio crate path

### DIFF
--- a/scripts/use-local-mshv-for-clh-build.sh
+++ b/scripts/use-local-mshv-for-clh-build.sh
@@ -14,6 +14,6 @@ replace_crate() {
 
 replace_crate mshv-bindings mshv/mshv-bindings
 replace_crate mshv-ioctls mshv/mshv-ioctls 
-replace_crate vfio-bindings vfio/crates/vfio-bindings
-replace_crate vfio-ioctls vfio/crates/vfio-ioctls
+replace_crate vfio-bindings vfio/vfio-bindings
+replace_crate vfio-ioctls vfio/vfio-ioctls
 replace_crate vfio_user vfio-user

--- a/scripts/use-local-mshv-for-vfio-build.sh
+++ b/scripts/use-local-mshv-for-vfio-build.sh
@@ -1,13 +1,13 @@
 #! /bin/sh
 
-filename=./crates/vfio-ioctls/Cargo.toml
+filename=./vfio-ioctls/Cargo.toml
 replace_crate() {
     line=$(grep -n "$1 = { version =" $filename | tail -n1 | cut -f1 -d:)
     if [ -z $line ]; then
             echo "$1 not found in the Cargo.toml file"
             exit 1
     fi
-    sed -i "$line i $1 = { path = \"..\/..\/..\/mshv\/$1\" $2" $filename
+    sed -i "$line i $1 = { path = \"..\/..\/mshv\/$1\" $2" $filename
     line=$((line+1))
     sed -i "${line}d" $filename
 }

--- a/scripts/use-local-vfio-for-vfio-user-build.sh
+++ b/scripts/use-local-vfio-for-vfio-user-build.sh
@@ -7,6 +7,6 @@ if [ -z $line ]; then
         echo "vfio-bindings not found in the Cargo.toml file"
         exit 1
 fi
-sed -i "$line i vfio-bindings = { path = \"../vfio/crates/vfio-bindings\" }" $filename
+sed -i "$line i vfio-bindings = { path = \"../vfio/vfio-bindings\" }" $filename
 line=$((line+1))
 sed -i "${line}d" $filename


### PR DESCRIPTION
In upstream VFIO crates there is a a chnage in the path of vfio-{bindings, ioctls} crate. This fixes the path for a successful CI run.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
