### PR TITLE
mshv-{bindings, ioctls): save and restore interrupt vectors

### DIFF
--- a/mshv-bindings/src/x86_64/regs.rs
+++ b/mshv-bindings/src/x86_64/regs.rs
@@ -702,6 +702,7 @@ pub struct SuspendRegisters {
 #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
 pub struct MiscRegs {
     pub hypercall: u64,
+    pub int_vec: u64,
 }
 
 const fn initialize_comp_sizes() -> [usize; MSHV_VP_STATE_COUNT as usize] {


### PR DESCRIPTION
If fast interrupt is used, interrupt vectors from register
page need to be saved and restored.


### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
