### PR TITLE
mshv-ioctls: Fix ARM64 guest default processor feature set

### DIFF
--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -93,6 +93,13 @@ fn make_partition_create_arg(vm_type: VmType) -> mshv_create_partition_v2 {
         proc_features.__bindgen_anon_1.set_rdtscp_support(0u64);
     }
 
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: access union fields
+    unsafe {
+        // This must always be enabled for ARM64 guests.
+        proc_features.__bindgen_anon_1.set_gic_v3v4(0u64);
+    }
+
     // SAFETY: access union fields
     unsafe {
         for i in 0..MSHV_NUM_CPU_FEATURES_BANKS {


### PR DESCRIPTION
### Summary of the PR

ARM64 always require GICV3V4 processor feature is enabled for the guests. Otherwise MSHV would fail the creation of partition.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
