### PR TITLE
ioctls: Add vm.initialize() to tests

### DIFF
--- a/mshv-ioctls/src/ioctls/device.rs
+++ b/mshv-ioctls/src/ioctls/device.rs
@@ -151,6 +151,7 @@ mod tests {
     fn test_create_device() {
         let mshv = Mshv::new().unwrap();
         let vm = mshv.create_vm().unwrap();
+        vm.initialize().unwrap();
 
         let mut device = mshv_bindings::mshv_create_device {
             type_: MSHV_DEV_TYPE_VFIO,

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -268,6 +268,7 @@ mod tests {
 
         /* Test all MSRs in the list individually and determine which can be get/set */
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let mut num_errors = 0;
         for idx in hv.get_msr_index_list().unwrap() {

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1808,6 +1808,7 @@ mod tests {
         for i in [0, 1] {
             let hv = Mshv::new().unwrap();
             let vm = hv.create_vm().unwrap();
+            vm.initialize().unwrap();
             let vcpu = vm.create_vcpu(0).unwrap();
 
             if i == 0 {
@@ -1861,6 +1862,7 @@ mod tests {
 
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         vcpu.hvcall_set_reg(&set_regs_assocs).unwrap();
@@ -1880,6 +1882,7 @@ mod tests {
     fn test_set_get_sregs() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let s_sregs = vcpu.get_sregs().unwrap();
         vcpu.set_sregs(&s_sregs).unwrap();
@@ -1899,6 +1902,7 @@ mod tests {
     fn test_set_get_standard_registers() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = vcpu.get_regs().unwrap();
@@ -1915,6 +1919,7 @@ mod tests {
     fn test_set_get_debug_registers() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = vcpu.get_debug_regs().unwrap();
@@ -1933,6 +1938,7 @@ mod tests {
     fn test_set_get_fpu() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = vcpu.get_fpu().unwrap();
@@ -1969,6 +1975,7 @@ mod tests {
 
         let mshv = Mshv::new().unwrap();
         let vm = mshv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         // This example is based on https://lwn.net/Articles/658511/
         #[rustfmt::skip]
@@ -2118,6 +2125,7 @@ mod tests {
 
         let mshv = Mshv::new().unwrap();
         let vm = mshv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         // This example is based on https://lwn.net/Articles/658511/
         #[rustfmt::skip]
@@ -2306,6 +2314,7 @@ mod tests {
     fn test_set_get_msrs() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = Msrs::from_entries(&[
@@ -2344,6 +2353,7 @@ mod tests {
     fn test_set_get_vcpu_events() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = vcpu.get_vcpu_events().unwrap();
@@ -2363,6 +2373,7 @@ mod tests {
     fn test_set_get_xcrs() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = vcpu.get_xcrs().unwrap();
@@ -2376,6 +2387,7 @@ mod tests {
     fn test_set_get_lapic() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let state = vcpu.get_lapic().unwrap();
@@ -2391,6 +2403,7 @@ mod tests {
     fn test_set_registers_64() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let arr_reg_name_value = [
             (hv_register_name_HV_X64_REGISTER_RIP, 0x1000),
@@ -2422,6 +2435,7 @@ mod tests {
     fn test_get_set_xsave() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let state = vcpu.get_xsave().unwrap();
@@ -2434,6 +2448,7 @@ mod tests {
     fn test_get_suspend_regs() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let regs = vcpu.get_suspend_regs().unwrap();
@@ -2447,6 +2462,7 @@ mod tests {
     fn test_set_get_misc_regs() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let s_regs = vcpu.get_misc_regs().unwrap();
@@ -2460,6 +2476,7 @@ mod tests {
     fn test_get_cpuid_values() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let res_0 = vcpu.get_cpuid_values(0, 0, 0, 0).unwrap();
         let max_function = res_0[0];
@@ -2474,6 +2491,7 @@ mod tests {
     fn test_get_set_vp_state_components() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let mut states = vcpu.get_all_vp_state_components().unwrap();
         vcpu.set_all_vp_state_components(&mut states).unwrap();

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -871,6 +871,7 @@ mod tests {
     fn test_user_memory() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let addr = unsafe {
             libc::mmap(
                 std::ptr::null_mut(),
@@ -898,6 +899,7 @@ mod tests {
     fn test_create_vcpu() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0);
         assert!(vcpu.is_ok());
     }
@@ -908,6 +910,7 @@ mod tests {
         /* TODO better test with some code */
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let state = vcpu.get_lapic().unwrap();
         let buffer = Buffer::try_from(&state).unwrap();
@@ -929,6 +932,7 @@ mod tests {
     fn test_install_intercept() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let intercept_args = mshv_install_intercept {
             access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
             intercept_type: hv_intercept_type_HV_INTERCEPT_TYPE_X64_CPUID,
@@ -949,6 +953,7 @@ mod tests {
     fn test_get_property() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
 
         let mut val = vm
             .get_partition_property(
@@ -1013,6 +1018,7 @@ mod tests {
     fn test_set_property() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
 
         let code = hv_partition_property_code_HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION;
         let ignore =
@@ -1041,6 +1047,7 @@ mod tests {
     fn test_set_partition_property_invalid() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let code = hv_partition_property_code_HV_PARTITION_PROPERTY_PRIVILEGE_FLAGS;
 
         // old IOCTL
@@ -1062,6 +1069,7 @@ mod tests {
         use libc::EFD_NONBLOCK;
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let efd = EventFd::new(EFD_NONBLOCK).unwrap();
         vm.register_irqfd(&efd, 30).unwrap();
         vm.unregister_irqfd(&efd, 30).unwrap();
@@ -1073,6 +1081,7 @@ mod tests {
         let addr = IoEventAddress::Mmio(0xe7e85004);
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         vm.register_ioevent(&efd, &addr, NoDatamatch).unwrap();
         vm.unregister_ioevent(&efd, &addr, NoDatamatch).unwrap();
     }
@@ -1081,6 +1090,7 @@ mod tests {
     fn test_set_msi_routing() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let msi_routing = mshv_user_irq_table::default();
         assert!(vm.set_msi_routing(&msi_routing).is_ok());
     }
@@ -1088,6 +1098,7 @@ mod tests {
     fn _test_clear_set_get_dirty_log(mem_size: usize) {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         // Try to allocate 32 MB memory
         let load_addr = unsafe {
             libc::mmap(
@@ -1173,6 +1184,7 @@ mod tests {
         // Enable the test once synic is implemented.
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let _vcpu = vm.create_vcpu(0).unwrap();
         vm.signal_event_direct(0, 0, 1).unwrap();
         vm.hvcall_signal_event_direct(0, 0, 1).unwrap();
@@ -1186,6 +1198,7 @@ mod tests {
         // Enable the test once synic is implemented.
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let _vcpu = vm.create_vcpu(0).unwrap();
         let hv_message: [u8; mem::size_of::<HvMessage>()] = [0; mem::size_of::<HvMessage>()];
         vm.post_message_direct(0, 0, &hv_message).unwrap();
@@ -1197,6 +1210,7 @@ mod tests {
     fn test_register_deliverabilty_notifications() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
         let _vcpu = vm.create_vcpu(0).unwrap();
         vm.register_deliverabilty_notifications(0, 0).unwrap();
         vm.hvcall_register_deliverability_notifications(0, 0)


### PR DESCRIPTION
It was removed from create_vm_with_type(), breaking the tests.
