### PR TITLE
mshv-ioctls: Fix a bug in translate gva hypercall

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1427,7 +1427,7 @@ impl VcpuFd {
         let mut args = make_args!(HVCALL_TRANSLATE_VIRTUAL_ADDRESS, input, output);
         self.hvcall(&mut args)?;
 
-        let gpa = (output.gpa_page << HV_HYP_PAGE_SHIFT) | (gva & !(1 << HV_HYP_PAGE_SHIFT));
+        let gpa = (output.gpa_page << HV_HYP_PAGE_SHIFT) | (gva & !(HV_HYP_PAGE_MASK as u64));
 
         Ok((gpa, output.translation_result))
     }


### PR DESCRIPTION
### Summary of the PR

We were using the incorrect mask to obtain the translated address from the hypercall.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
