### PR TITLE
Fix ioctl invocations

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1720,7 +1720,7 @@ impl VcpuFd {
     /// Execute a hypercall for this vp
     pub fn hvcall(&self, args: &mut mshv_root_hvcall) -> Result<()> {
         // SAFETY: IOCTL with correct types
-        let ret = unsafe { ioctl_with_ref(self, MSHV_ROOT_HVCALL(), args) };
+        let ret = unsafe { ioctl_with_mut_ref(self, MSHV_ROOT_HVCALL(), args) };
         if ret == 0 {
             Ok(())
         } else {

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -794,7 +794,7 @@ impl VmFd {
     /// See the documentation for `MSHV_CREATE_DEVICE`.
     pub fn create_device(&self, device: &mut mshv_create_device) -> Result<DeviceFd> {
         // SAFETY: IOCTL with correct types
-        let ret = unsafe { ioctl_with_ref(self, MSHV_CREATE_DEVICE(), device) };
+        let ret = unsafe { ioctl_with_mut_ref(self, MSHV_CREATE_DEVICE(), device) };
         if ret == 0 {
             // SAFETY: fd is valid
             Ok(new_device(unsafe { File::from_raw_fd(device.fd as i32) }))

--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -806,7 +806,7 @@ impl VmFd {
     /// Execute a hypercall for this partition
     pub fn hvcall(&self, args: &mut mshv_root_hvcall) -> Result<()> {
         // SAFETY: IOCTL with correct types
-        let ret = unsafe { ioctl_with_ref(self, MSHV_ROOT_HVCALL(), args) };
+        let ret = unsafe { ioctl_with_mut_ref(self, MSHV_ROOT_HVCALL(), args) };
         if ret == 0 {
             Ok(())
         } else {


### PR DESCRIPTION
### Summary of the PR

`ROOT_HVCALL` and `MSHV_CREATE_DEVICE` ioctl invocation should use `ioctl_with_mut_ref` to receive data from the kernel

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
