### PR TITLE
scripts: temp fix to unblock the CI

### DIFF
--- a/mshv-ioctls/src/ioctls/mod.rs
+++ b/mshv-ioctls/src/ioctls/mod.rs
@@ -30,7 +30,7 @@ pub enum MshvError {
     ///
     /// In case the caller requires an errno, this variant can be still be
     /// converted to an EIO with into(), from(), or errno() for the raw value
-    #[error("Hypercall {code} failed with {status_raw:#x} : {}", status.map_or("Unknown".to_string(), |s| format!("{:?}", s)))]
+    #[error("Hypercall {code} failed with {status_raw:#x} : {}", status.map_or("Unknown".to_string(), |s| format!("{s:?}")))]
     Hypercall {
         /// The control code, i.e. what type of hypercall it was
         code: u16,

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -278,12 +278,12 @@ mod tests {
             }])
             .unwrap();
             vcpu.get_msrs(&mut get_set_msrs).unwrap_or_else(|_| {
-                println!("Error getting MSR: 0x{:x}", idx);
+                println!("Error getting MSR: 0x{idx:x}");
                 num_errors += 1;
                 0
             });
             vcpu.set_msrs(&get_set_msrs).unwrap_or_else(|_| {
-                println!("Error setting MSR: 0x{:x}", idx);
+                println!("Error setting MSR: 0x{idx:x}");
                 num_errors += 1;
                 0
             });

--- a/scripts/use-local-mshv-for-vfio-build.sh
+++ b/scripts/use-local-mshv-for-vfio-build.sh
@@ -14,3 +14,17 @@ replace_crate() {
 
 replace_crate mshv-ioctls ', optional  = true }'
 replace_crate mshv-bindings ', features = ['
+
+
+# Below is a temporary workaround to fix ongoing pipeline issues.
+# This should be removed once
+# https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7123 is merged.
+# Summary: vfio crate picked up newer versions of dependencies, which conflict
+#     with the versions within cloud-hypervisor. This script downgrades the
+#     dependencies used by vfio to the versions used by cloud-hypervisor.
+
+sed -e 's/^kvm-bindings.*$/kvm-bindings = { version = "0.10.0", optional = true }/g' -i $filename
+sed -e 's/^kvm-ioctls.*$/kvm-ioctls = { version = "0.19.1", optional = true }/g' -i $filename
+
+vfio_cargo="./Cargo.toml"
+sed -e 's/^vmm-sys-util.*$/vmm-sys-util = "0.12.1"/g' -i $vfio_cargo


### PR DESCRIPTION
Downgrade the versions of kvm-bindings, kvm-ioctls and vmm-sys-util until the newer versions are picked up by cloud-hypervisor upstream.



### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
