### PR TITLE
Revert "build: Bump vmm-sys-util from v0.12.1 to v0.14.0"

### DIFF
--- a/mshv-bindings/Cargo.toml
+++ b/mshv-bindings/Cargo.toml
@@ -18,7 +18,7 @@ libc = ">=0.2.39"
 num_enum = { version = "0.7", default-features = false }
 serde = { version = ">=1.0.27", optional = true }
 serde_derive = { version = ">=1.0.27", optional = true }
-vmm-sys-util = ">=0.14.0"
+vmm-sys-util = ">=0.12.1"
 zerocopy = { version = "0.8", features = ["derive"] }
 
 [dev-dependencies]

--- a/mshv-ioctls/Cargo.toml
+++ b/mshv-ioctls/Cargo.toml
@@ -15,4 +15,4 @@ mshv-bindings = { version = "=0.5.1", path = "../mshv-bindings", features = [
   "fam-wrappers",
 ] }
 thiserror = "2.0"
-vmm-sys-util = ">=0.14.0"
+vmm-sys-util = ">=0.12.1"


### PR DESCRIPTION
This reverts commit ce209bb243debe6fd6c279fcc066f877bedb5138.
It breaks the temporary CI fix from https://github.com/rust-vmm/mshv/pull/235.
The dependency can be bumped again later.