### PR TITLE
Revert "scripts: temp fix to unblock the CI"

### DIFF
--- a/scripts/use-local-mshv-for-vfio-build.sh
+++ b/scripts/use-local-mshv-for-vfio-build.sh
@@ -14,17 +14,3 @@ replace_crate() {
 
 replace_crate mshv-ioctls ', optional  = true }'
 replace_crate mshv-bindings ', features = ['
-
-
-# Below is a temporary workaround to fix ongoing pipeline issues.
-# This should be removed once
-# https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7123 is merged.
-# Summary: vfio crate picked up newer versions of dependencies, which conflict
-#     with the versions within cloud-hypervisor. This script downgrades the
-#     dependencies used by vfio to the versions used by cloud-hypervisor.
-
-sed -e 's/^kvm-bindings.*$/kvm-bindings = { version = "0.10.0", optional = true }/g' -i $filename
-sed -e 's/^kvm-ioctls.*$/kvm-ioctls = { version = "0.19.1", optional = true }/g' -i $filename
-
-vfio_cargo="./Cargo.toml"
-sed -e 's/^vmm-sys-util.*$/vmm-sys-util = "0.12.1"/g' -i $vfio_cargo


### PR DESCRIPTION
This reverts commit 2d14df227258ec3886143ce88366de0f6f6aa685, since cloud hypervisor kvm versions are up to date with vfio now.