### PR TITLE
mshv:ioctls munmap register page

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1772,6 +1772,17 @@ impl VcpuFd {
     }
 }
 
+impl Drop for VcpuFd {
+    fn drop(&mut self) {
+        if let Some(vp_page) = &self.vp_page {
+            // SAFETY: because we ensured vp_page is valid in create_vcpu.
+            unsafe {
+                let _ = libc::munmap(vp_page.0 as *mut libc::c_void, HV_PAGE_SIZE);
+            }
+        }
+    }
+}
+
 #[allow(dead_code)]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Make sure that the register page is unmapped when the vcpu object is dropped Add tests to ensure that resources are not leaked

### Summary of the PR

#194 details a regression that was found moving from version 0.3.2 to version 0.3.3 of the mshv crates, this was caused by the changes in #183 that mmap the register page on creation of a vcpu not having a corresponding munmap when the vcpu is dropped resulting in resource not being freed.

The PR adds a drop impl to conditionally unmap the register page

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
