### PR TITLE
mshv-ioctls: enable PMU for arm64 guests

### DIFF
--- a/mshv-ioctls/CHANGELOG.md
+++ b/mshv-ioctls/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 * [[254]](https://github.com/rust-vmm/mshv/pull/254) Enable RDRAND support for x86 guests
+* [[253]](https://github.com/rust-vmm/mshv/pull/253) Enable PMU for arm64 guests
 
 ### Deprecated
 

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -109,6 +109,8 @@ fn make_partition_create_arg(vm_type: VmType) -> mshv_create_partition_v2 {
         proc_features.__bindgen_anon_1.set_fp_hp(0);
         proc_features.__bindgen_anon_1.set_adv_simd(0);
         proc_features.__bindgen_anon_1.set_adv_simd_hp(0);
+
+        proc_features.__bindgen_anon_1.set_pmu_v3(0);
     }
 
     // SAFETY: access union fields


### PR DESCRIPTION
Expose PMU to arm64 guests. Fixes the test_pmu_on testcase in CLH.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
