### PR TITLE
mshv-ioctls: enable RDRAND support for x86 guests

### DIFF
--- a/mshv-ioctls/CHANGELOG.md
+++ b/mshv-ioctls/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 ### Changed
+* [[254]](https://github.com/rust-vmm/mshv/pull/254) Enable RDRAND support for x86 guests
 
 ### Deprecated
 

--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -89,6 +89,7 @@ fn make_partition_create_arg(vm_type: VmType) -> mshv_create_partition_v2 {
         create_args.pt_disabled_xsave = xsave_features.as_uint64;
 
         // Enable default processor features that are known to be supported
+        proc_features.__bindgen_anon_1.set_rd_rand_support(0u64);
         proc_features.__bindgen_anon_1.set_cet_ibt_support(0u64);
         proc_features.__bindgen_anon_1.set_cet_ss_support(0u64);
         proc_features.__bindgen_anon_1.set_smep_support(0u64);


### PR DESCRIPTION
This is needed specifically for SEV-SNP guests. Without this CVM guests don't boot.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
