### PR TITLE
.github: update PR trigger for mshv workflow

### DIFF
--- a/.github/workflows/mshv-tests.yaml
+++ b/.github/workflows/mshv-tests.yaml
@@ -1,12 +1,9 @@
 name: Build & Test MSHV Crate
 on: 
-  pull_request:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to build and test'
-        required: true
-        default: 'main'
+  pull_request_target:
+  push:
+    branches:
+      - main
 jobs:
   infra-setup:
     name: MSHV Infra Setup (x86_64)
@@ -32,21 +29,13 @@ jobs:
       - self-hosted
       - Linux
     steps:
-      - name: Determine branch to build
-        run: |
-          echo "Determining branch to build and test..."
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          else
-            echo "BRANCH=${{ inputs.branch }}" >> $GITHUB_ENV
-          fi
-
       - name: Build & Run tests on remote VM
         env:
-          BRANCH_NAME: ${{ env.BRANCH }}
           KEY: azure_key_${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PRIVATE_IP: ${{ needs.infra-setup.outputs.PRIVATE_IP }}
+          REPO_URL: https://github.com/rust-vmm/mshv.git
+          REPO_DIR: mshv
           RG: MSHV-${{ github.run_id }}
           USERNAME: ${{ secrets.MSHV_USERNAME }}
         run: |
@@ -56,9 +45,17 @@ jobs:
             set -e
             echo "Logged in successfully."
             export PATH="\$HOME/.cargo/bin:\$PATH"
-            echo "${BRANCH_NAME}"
-            git clone --depth 1 --single-branch --branch "$BRANCH_NAME" https://github.com/rust-vmm/mshv.git
-            cd mshv
+
+            if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+              git clone --depth 1 "$REPO_URL" "$REPO_DIR"
+              cd "$REPO_DIR"
+              git fetch origin pull/${{ github.event.pull_request.number }}/merge
+              git checkout FETCH_HEAD
+            else
+              git clone --depth 1 --single-branch --branch "${{ github.ref_name }}" "$REPO_URL" "$REPO_DIR"
+              cd "$REPO_DIR"
+            fi
+
             cargo build --all-features --workspace
             cargo test --all-features --workspace
           EOF


### PR DESCRIPTION
### Summary of the PR
Forked pull requests cannot access GitHub secrets, which results in failure of MSHV CI.  Switching to `pull_request_target` resolves this.

- Replace `pull_request` trigger with `pull_request_target` as it allows the workflow to run with access to repo secrets and ensures that code from the base branch is used instead of forked code, preventing potential security risks.

- Added trigger on `push` to `main`. It ensures that the workflow also run after changes are merged.
 
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
