### PR TITLE
build: disable CLH build for now

### DIFF
--- a/.github/workflows/clh_build.yaml
+++ b/.github/workflows/clh_build.yaml
@@ -3,7 +3,8 @@ on: [pull_request, create]
 
 jobs:
   build:
-    if: github.event_name == 'pull_request'
+
+    if: false # This job will always be skipped for now
     name: Cloud Hypervisor Build using MSHV changes
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
There are too many dependency for this workflow. It's always error prune and frequently changed version in many crates across 3 or more repositories. Disabling for now until good resolution is found.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
