### PR TITLE
.github: skip commit message validation for PRs by bot

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -21,5 +21,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade gitlint
     - name: Lint git commit messages
+      if: github.actor != 'dependabot[bot]'
       run: |
         gitlint --commits origin/$GITHUB_BASE_REF..


### PR DESCRIPTION
Sometimes PR created by dependabot might not meet the requirement of commit message due to dependent
package with long name and some other information. It's better to avoid commit message validation for such  PRs.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
