### PR TITLE
mshv-ioctls: expose two APIs

### DIFF
--- a/mshv-ioctls/src/lib.rs
+++ b/mshv-ioctls/src/lib.rs
@@ -203,6 +203,7 @@
 mod ioctls;
 pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Mshv;
+pub use ioctls::system::{make_default_partition_create_arg, make_default_synthetic_features_mask};
 pub use ioctls::vcpu::VcpuFd;
 pub use ioctls::vm::InterruptRequest;
 pub use ioctls::vm::IoEventAddress;


### PR DESCRIPTION
Expost make_default_partition_create_arg and
make_default_synthetic_features_mask for VMM
to use.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
