### PR TITLE
mshv-ioctls: rename variables for proc & xsave features

### DIFF
--- a/mshv-ioctls/src/ioctls/system.rs
+++ b/mshv-ioctls/src/ioctls/system.rs
@@ -65,154 +65,286 @@ pub fn make_default_partition_create_arg(vm_type: VmType) -> mshv_create_partiti
         ..Default::default()
     };
 
-    let mut proc_features = hv_partition_processor_features::default();
-    let mut xsave_features = hv_partition_processor_xsave_features::default();
+    let mut disabled_proc_features = hv_partition_processor_features::default();
+    let mut disabled_xsave_features = hv_partition_processor_xsave_features::default();
     for i in 0..MSHV_NUM_CPU_FEATURES_BANKS {
         // SAFETY: access union fields
         unsafe {
-            proc_features.as_uint64[i as usize] = 0xFFFFFFFFFFFFFFFF;
+            disabled_proc_features.as_uint64[i as usize] = 0xFFFFFFFFFFFFFFFF;
         }
     }
-    xsave_features.as_uint64 = 0xFFFFFFFFFFFFFFFF;
+    disabled_xsave_features.as_uint64 = 0xFFFFFFFFFFFFFFFF;
 
     #[cfg(target_arch = "x86_64")]
     // SAFETY: access union fields
     unsafe {
         // Enable default XSave features that are known to be supported
-        xsave_features.__bindgen_anon_1.set_avx_support(0u64);
-        xsave_features.__bindgen_anon_1.set_xsave_comp_support(0u64);
-        xsave_features
+        disabled_xsave_features
+            .__bindgen_anon_1
+            .set_avx_support(0u64);
+        disabled_xsave_features
+            .__bindgen_anon_1
+            .set_xsave_comp_support(0u64);
+        disabled_xsave_features
             .__bindgen_anon_1
             .set_xsave_supervisor_support(0u64);
-        xsave_features.__bindgen_anon_1.set_xsave_support(0u64);
-        xsave_features.__bindgen_anon_1.set_xsaveopt_support(0u64);
-        create_args.pt_disabled_xsave = xsave_features.as_uint64;
+        disabled_xsave_features
+            .__bindgen_anon_1
+            .set_xsave_support(0u64);
+        disabled_xsave_features
+            .__bindgen_anon_1
+            .set_xsaveopt_support(0u64);
+        create_args.pt_disabled_xsave = disabled_xsave_features.as_uint64;
 
         // Enable default processor features that are known to be supported
-        proc_features.__bindgen_anon_1.set_adx_support(0u64);
-        proc_features.__bindgen_anon_1.set_aes_support(0u64);
-        proc_features.__bindgen_anon_1.set_altmovcr8_support(0u64);
-        proc_features.__bindgen_anon_1.set_amd3dnow_support(0u64);
-        proc_features.__bindgen_anon_1.set_bhi_dis_support(0u64);
-        proc_features.__bindgen_anon_1.set_bhi_no_support(0u64);
-        proc_features.__bindgen_anon_1.set_bmi1_support(0u64);
-        proc_features.__bindgen_anon_1.set_bmi2_support(0u64);
-        proc_features.__bindgen_anon_1.set_btc_no_support(0u64);
-        proc_features.__bindgen_anon_1.set_cet_ibt_support(0u64);
-        proc_features.__bindgen_anon_1.set_cet_ss_support(0u64);
-        proc_features.__bindgen_anon_1.set_clflushopt_support(0u64);
-        proc_features.__bindgen_anon_1.set_cmpxchg16b_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_adx_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_aes_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_altmovcr8_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_amd3dnow_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_bhi_dis_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_bhi_no_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_bmi1_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_bmi2_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_btc_no_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_cet_ibt_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_cet_ss_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_clflushopt_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_cmpxchg16b_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_dep_x87_fpu_save_support(0u64);
-        proc_features
+        disabled_proc_features
             .__bindgen_anon_1
             .set_enhanced_fast_string_support(0u64);
-        proc_features
+        disabled_proc_features
             .__bindgen_anon_1
             .set_extended_amd3dnow_support(0u64);
-        proc_features.__bindgen_anon_1.set_f16c_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_f16c_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_fast_short_rep_mov_support(0u64);
-        proc_features.__bindgen_anon_1.set_fb_clear_support(0u64);
-        proc_features.__bindgen_anon_1.set_fma4_support(0u64);
-        proc_features.__bindgen_anon_1.set_gds_no_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_fb_clear_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_fma4_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_gds_no_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_hle_support_deprecated(0u64);
-        proc_features.__bindgen_anon_1.set_hle_support(0u64);
-        proc_features.__bindgen_anon_1.set_ibpb_support(0u64);
-        proc_features.__bindgen_anon_1.set_ibrs_all_support(0u64);
-        proc_features.__bindgen_anon_1.set_ibrs_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_hle_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_ibpb_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_ibrs_all_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_ibrs_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_intel_prefetch_support(0u64);
-        proc_features.__bindgen_anon_1.set_invpcid_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_invpcid_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_l1dcache_flush_support(0u64);
-        proc_features.__bindgen_anon_1.set_lahf_sahf_support(0u64);
-        proc_features.__bindgen_anon_1.set_lzcnt_support(0u64);
-        proc_features.__bindgen_anon_1.set_mb_clear_support(0u64);
-        proc_features.__bindgen_anon_1.set_mbec_support(0u64);
-        proc_features.__bindgen_anon_1.set_mbs_no_support(0u64);
-        proc_features.__bindgen_anon_1.set_mdd_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_lahf_sahf_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_lzcnt_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_mb_clear_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_mbec_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_mbs_no_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_mdd_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_mis_align_sse_support(0u64);
-        proc_features
+        disabled_proc_features
             .__bindgen_anon_1
             .set_mitigation_ctrl_support(0u64);
-        proc_features.__bindgen_anon_1.set_mmx_ext_support(0u64);
-        proc_features.__bindgen_anon_1.set_movbe_support(0u64);
-        proc_features.__bindgen_anon_1.set_npiep1_support(0u64);
-        proc_features.__bindgen_anon_1.set_page_1gb_support(0u64);
-        proc_features.__bindgen_anon_1.set_pclmulqdq_support(0u64);
-        proc_features.__bindgen_anon_1.set_pcid_support(0u64);
-        proc_features.__bindgen_anon_1.set_pop_cnt_support(0u64);
-        proc_features.__bindgen_anon_1.set_psfd_support(0u64);
-        proc_features.__bindgen_anon_1.set_rd_pid_support(0u64);
-        proc_features.__bindgen_anon_1.set_rd_rand_support(0u64);
-        proc_features.__bindgen_anon_1.set_rd_rand_support(0u64);
-        proc_features.__bindgen_anon_1.set_rd_seed_support(0u64);
-        proc_features.__bindgen_anon_1.set_rd_wr_fs_gs_support(0u64);
-        proc_features.__bindgen_anon_1.set_rdcl_no_support(0u64);
-        proc_features.__bindgen_anon_1.set_rdpru_support(0u64);
-        proc_features.__bindgen_anon_1.set_rdtscp_support(0u64);
-        proc_features.__bindgen_anon_1.set_rfds_clear_support(0u64);
-        proc_features.__bindgen_anon_1.set_rfds_no_support(0u64);
-        proc_features.__bindgen_anon_1.set_rsb_a_no_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_mmx_ext_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_movbe_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_npiep1_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_page_1gb_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_pclmulqdq_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_pcid_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_pop_cnt_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_psfd_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rd_pid_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rd_rand_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rd_rand_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rd_seed_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rd_wr_fs_gs_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rdcl_no_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rdpru_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rdtscp_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rfds_clear_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rfds_no_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rsb_a_no_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_rtm_support_deprecated(0u64);
-        proc_features.__bindgen_anon_1.set_rtm_support(0u64);
-        proc_features.__bindgen_anon_1.set_skip_l1df_support(0u64);
-        proc_features.__bindgen_anon_1.set_smap_support(0u64);
-        proc_features.__bindgen_anon_1.set_smep_support(0u64);
-        proc_features.__bindgen_anon_1.set_ssb_no_support(0u64);
-        proc_features.__bindgen_anon_1.set_sse3_support(0u64);
-        proc_features.__bindgen_anon_1.set_sse4_1_support(0u64);
-        proc_features.__bindgen_anon_1.set_sse4_2_support(0u64);
-        proc_features.__bindgen_anon_1.set_sse4a_support(0u64);
-        proc_features.__bindgen_anon_1.set_ssse3_support(0u64);
-        proc_features.__bindgen_anon_1.set_stibp_support(0u64);
-        proc_features.__bindgen_anon_1.set_taa_no_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_rtm_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_skip_l1df_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_smap_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_smep_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_ssb_no_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_sse3_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_sse4_1_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_sse4_2_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_sse4a_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_ssse3_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_stibp_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_taa_no_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_tsc_invariant_support(0u64);
-        proc_features.__bindgen_anon_1.set_tsx_ctrl_support(0u64);
-        proc_features.__bindgen_anon_1.set_umip_support(0u64);
-        proc_features
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_tsx_ctrl_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_umip_support(0u64);
+        disabled_proc_features
             .__bindgen_anon_1
             .set_unrestricted_guest_support(0u64);
-        proc_features
+        disabled_proc_features
             .__bindgen_anon_1
             .set_virt_spec_ctrl_support(0u64);
-        proc_features
+        disabled_proc_features
             .__bindgen_anon_1
             .set_vmx_exception_inject_support(0u64);
-        proc_features.__bindgen_anon_1.set_xop_support(0u64);
+        disabled_proc_features
+            .__bindgen_anon_1
+            .set_xop_support(0u64);
     }
 
     #[cfg(target_arch = "aarch64")]
     // SAFETY: access union fields
     unsafe {
         // This must always be enabled for ARM64 guests.
-        proc_features.__bindgen_anon_1.set_gic_v3v4(0u64);
+        disabled_proc_features.__bindgen_anon_1.set_gic_v3v4(0u64);
 
-        proc_features.__bindgen_anon_1.set_fp(0);
-        proc_features.__bindgen_anon_1.set_fp_hp(0);
-        proc_features.__bindgen_anon_1.set_adv_simd(0);
-        proc_features.__bindgen_anon_1.set_adv_simd_hp(0);
+        disabled_proc_features.__bindgen_anon_1.set_fp(0);
+        disabled_proc_features.__bindgen_anon_1.set_fp_hp(0);
+        disabled_proc_features.__bindgen_anon_1.set_adv_simd(0);
+        disabled_proc_features.__bindgen_anon_1.set_adv_simd_hp(0);
 
-        proc_features.__bindgen_anon_1.set_pmu_v3(0);
+        disabled_proc_features.__bindgen_anon_1.set_pmu_v3(0);
     }
 
     // SAFETY: access union fields
     unsafe {
         for i in 0..MSHV_NUM_CPU_FEATURES_BANKS {
-            create_args.pt_cpu_fbanks[i as usize] = proc_features.as_uint64[i as usize];
+            create_args.pt_cpu_fbanks[i as usize] = disabled_proc_features.as_uint64[i as usize];
         }
     }
 


### PR DESCRIPTION
These variables denote *disabled* processor/xsave features. Name them as such for better readability. Otherwise it is confusing why feature bits are being set to 0 in order to enable them.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
