### PR TITLE
mshv-ioctls: Use dedicated ioctl for GVA to GPA translation

### DIFF
--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1410,9 +1410,37 @@ impl VcpuFd {
         };
         self.set_vp_state_ioctl(&vp_state)
     }
-    /// Translate guest virtual address to guest physical address
+    /// Translate guest virtual address to guest physical address.
+    ///
+    /// Tries the dedicated `MSHV_VP_TRANSLATE_GVA` ioctl first (which handles
+    /// transient GPA access failures by faulting pages back in). Falls back
+    /// to the generic hypercall passthrough if the kernel does not support
+    /// the new ioctl (`ENOTTY`).
     pub fn translate_gva(&self, gva: u64, flags: u64) -> Result<(u64, hv_translate_gva_result)> {
-        self.hvcall_translate_gva(gva, flags)
+        match self.ioctl_translate_gva(gva, flags) {
+            Err(MshvError::Errno(e)) if e.errno() == libc::ENOTTY => {
+                self.hvcall_translate_gva(gva, flags)
+            }
+            other => other,
+        }
+    }
+    /// Dedicated ioctl for GVA translation with transparent fault-in
+    /// handling for movable memory regions.
+    fn ioctl_translate_gva(&self, gva: u64, flags: u64) -> Result<(u64, hv_translate_gva_result)> {
+        let mut result = hv_translate_gva_result::default();
+        let mut gpa: u64 = 0;
+        let mut args = mshv_translate_gva {
+            gva,
+            flags,
+            result: &mut result,
+            gpa: &mut gpa,
+        };
+        // SAFETY: IOCTL with correct types, result and gpa pointers are valid
+        let ret = unsafe { ioctl_with_mut_ref(self, MSHV_VP_TRANSLATE_GVA(), &mut args) };
+        if ret != 0 {
+            return Err(errno::Error::last().into());
+        }
+        Ok((gpa, result))
     }
     /// Generic hvcall version of translate guest virtual address
     fn hvcall_translate_gva(&self, gva: u64, flags: u64) -> Result<(u64, hv_translate_gva_result)> {


### PR DESCRIPTION
Use MSHV_VP_TRANSLATE_GVA ioctl instead of the generic hypercall passthrough for guest virtual address translation. The dedicated ioctl handles transient GPA access failures (e.g. HV_TRANSLATE_GVA_GPA_NO_READ_ACCESS) by faulting pages back in transparently, which fixes translation failures that occur when guest page table pages reside in movable memory regions and their NPT entries are temporarily invalidated.

Fall back to the hypercall passthrough on ENOTTY for kernels that do not yet support the dedicated ioctl.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.

### Note

This change restores a previously existing ioctl. The kernel can expose it under the same ioctl number, so there is no need to regenerate the headers: they already contain the ABI for the earlier implementation of this ioctl.