### PR TITLE
ioctls: Fix device fd ioctl numbers to match kernel UAPI

### DIFF
--- a/mshv-ioctls/CHANGELOG.md
+++ b/mshv-ioctls/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 
 ### Fixed
+* mshv-ioctls: Fix device fd ioctl numbers for kernel 6.18 (remove MSHV_GET_DEVICE_ATTR, renumber MSHV_HAS_DEVICE_ATTR from 0x02 to 0x01)
 
 ## [v0.6.9]
 

--- a/mshv-ioctls/src/ioctls/device.rs
+++ b/mshv-ioctls/src/ioctls/device.rs
@@ -5,10 +5,10 @@ use std::fs::File;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use crate::ioctls::Result;
-use crate::mshv_ioctls::{MSHV_GET_DEVICE_ATTR, MSHV_HAS_DEVICE_ATTR, MSHV_SET_DEVICE_ATTR};
+use crate::mshv_ioctls::{MSHV_HAS_DEVICE_ATTR, MSHV_SET_DEVICE_ATTR};
 use mshv_bindings::mshv_device_attr;
 use vmm_sys_util::errno;
-use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref};
+use vmm_sys_util::ioctl::ioctl_with_ref;
 
 /// Wrapper over the file descriptor obtained when creating an emulated device in the kernel.
 #[derive(Debug)]
@@ -83,35 +83,6 @@ impl DeviceFd {
         }
         Ok(())
     }
-
-    /// Gets a specified piece of device configuration and/or state.
-    ///
-    /// See the documentation for `MSHV_GET_DEVICE_ATTR`.
-    ///
-    /// # Arguments
-    ///
-    /// * `device_attr` - The device attribute to be get.
-    /// Note: This argument serves as both input and output.
-    /// When calling this function, the user should explicitly provide
-    /// valid values for the `group` and the `attr` field of the
-    /// `mshv_device_attr` structure, and a valid userspace address
-    /// (i.e. the `addr` field) to access the returned device attribute
-    /// data.
-    ///
-    /// # Returns
-    ///
-    /// * Returns the last occured `errno` wrapped in an `Err`.
-    /// * `device_attr` - The `addr` field of the `device_attr` structure will point to
-    /// the device attribute data.
-    pub fn get_device_attr(&self, device_attr: &mut mshv_device_attr) -> Result<()> {
-        // SAFETY: IOCTL. We're sure parameters are of the correct types and meet safety
-        // requirements.
-        let ret = unsafe { ioctl_with_mut_ref(self, MSHV_GET_DEVICE_ATTR(), device_attr) };
-        if ret != 0 {
-            return Err(errno::Error::last().into());
-        }
-        Ok(())
-    }
 }
 
 /// Helper function for creating a new device.
@@ -177,12 +148,9 @@ mod tests {
             flags: 0,
         };
 
-        let mut dist_attr_mut = dist_attr;
-
         // We are just creating a test device. Creating a real device would make the CI dependent
         // on host configuration (like having /dev/vfio). We expect this to fail.
         assert!(device.has_device_attr(&dist_attr).is_ok());
-        assert!(device.get_device_attr(&mut dist_attr_mut).is_err());
         assert!(device.set_device_attr(&dist_attr).is_err());
         assert_eq!(errno::Error::last().errno(), 14);
     }

--- a/mshv-ioctls/src/mshv_ioctls.rs
+++ b/mshv-ioctls/src/mshv_ioctls.rs
@@ -146,5 +146,4 @@ ioctl_iow_nr!(MSHV_WRITE_GPA, MSHV_IOCTL, 0xF6, mshv_read_write_gpa);
 
 // device fd
 ioctl_iow_nr!(MSHV_SET_DEVICE_ATTR, MSHV_IOCTL, 0x00, mshv_device_attr);
-ioctl_iow_nr!(MSHV_GET_DEVICE_ATTR, MSHV_IOCTL, 0x01, mshv_device_attr);
-ioctl_iow_nr!(MSHV_HAS_DEVICE_ATTR, MSHV_IOCTL, 0x02, mshv_device_attr);
+ioctl_iow_nr!(MSHV_HAS_DEVICE_ATTR, MSHV_IOCTL, 0x01, mshv_device_attr);


### PR DESCRIPTION
The kernel 6.18 reorganized the mshv device fd UAPI. In 6.6:

    #define MSHV_SET_DEVICE_ATTR  _IOW(MSHV_IOCTL, 0x00, struct mshv_device_attr)
    #define MSHV_GET_DEVICE_ATTR  _IOW(MSHV_IOCTL, 0x01, struct mshv_device_attr)
    #define MSHV_HAS_DEVICE_ATTR  _IOW(MSHV_IOCTL, 0x02, struct mshv_device_attr)

In 6.18, MSHV_GET_DEVICE_ATTR was removed and MSHV_HAS_DEVICE_ATTR was renumbered to 0x01:

    #define MSHV_SET_DEVICE_ATTR  _IOW(MSHV_IOCTL, 0x00, struct mshv_device_attr)
    #define MSHV_HAS_DEVICE_ATTR  _IOW(MSHV_IOCTL, 0x01, struct mshv_device_attr)

The crate still uses the 6.6 layout, causing has_device_attr() to send ioctl command 0x02 which the 6.18 kernel does not recognize, returning -ENOTTY. This makes test_create_device panic on:

    assertion failed: device.has_device_attr(&dist_attr).is_ok()

Update the crate to match the 6.18 UAPI:
- Remove MSHV_GET_DEVICE_ATTR ioctl definition
- Fix MSHV_HAS_DEVICE_ATTR number from 0x02 to 0x01
- Remove get_device_attr() method from DeviceFd
- Update test_create_device accordingly

Note: this breaks compatibility with the 6.6 kernel.