### PR TITLE
mshv-bindings: use alloc_zeroed for Buffer:new()

### DIFF
--- a/mshv-bindings/src/x86_64/regs.rs
+++ b/mshv-bindings/src/x86_64/regs.rs
@@ -475,8 +475,11 @@ pub struct Buffer {
 impl Buffer {
     pub fn new(size: usize, align: usize) -> Result<Buffer, errno::Error> {
         let layout = std::alloc::Layout::from_size_align(size, align).unwrap();
-        // SAFETY: layout is valid
-        let buf = unsafe { std::alloc::alloc(layout) };
+        // SAFETY: layout is valid. Using alloc_zeroed to ensure the buffer is
+        // fully initialised — callers like get_xsave() pass this buffer to a
+        // kernel ioctl that may only partially fill it (writing buf_sz bytes),
+        // leaving the remainder as whatever alloc returned.
+        let buf = unsafe { std::alloc::alloc_zeroed(layout) };
         if buf.is_null() {
             return Err(errno::Error::new(libc::ENOMEM));
         }


### PR DESCRIPTION
### Summary of the PR

`mshv_bindings::Buffer::new` allocates memory with `std::alloc::alloc` which does not zero the buffer. When used by `mshv_ioctls::VcpuFd::get_xsave()`, the MSHV ioctl only writes `buf_sz` bytes of valid data (e.g. 2432 bytes for XSAVE), but the full 4096-byte buffer — including 1664 bytes of uninitialised memory — is returned to the caller via `XSave::try_from(buffer)`.

This PR fixes that issue by using `alloc_zeroed` instead of `alloc`

This issue also impacts `get_lapic()` and the fix covers that as well.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.

Fixes #325 