### PR TITLE
mshv-ioctls: Drop interrupt_bitmap check in set_sregs

### DIFF
--- a/mshv-ioctls/CHANGELOG.md
+++ b/mshv-ioctls/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 
 ### Fixed
+* [[334]](https://github.com/rust-vmm/mshv/pull/334) mshv-ioctls: Drop interrupt_bitmap check in set_sregs
 
 ## [v0.6.9]
 

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -613,6 +613,8 @@ impl VcpuFd {
             ret_regs.idt = TableRegister::from(reg_assocs[3].value.table);
             ret_regs.cr2 = reg_assocs[4].value.reg64;
             ret_regs.apic_base = reg_assocs[5].value.reg64;
+            // A VMM can use the bitmap to reassert a pending external interrupt
+            // for a live migrating guest.
             update_interrupt_bitmap(
                 &mut ret_regs,
                 reg_assocs[6].value.pending_interruption.as_uint64,
@@ -675,6 +677,8 @@ impl VcpuFd {
             ret_regs.cr8 = reg_assocs[9].value.reg64;
             ret_regs.efer = reg_assocs[10].value.reg64;
             ret_regs.apic_base = reg_assocs[16].value.reg64;
+            // A VMM can use the bitmap to reassert a pending external interrupt
+            // for a live migrating guest.
             update_interrupt_bitmap(
                 &mut ret_regs,
                 reg_assocs[17].value.pending_interruption.as_uint64,
@@ -776,13 +780,6 @@ impl VcpuFd {
             },
         ];
 
-        // TODO support asserting an interrupt using interrupt_bitmap
-        // we can't do this without the vm fd which isn't available here
-        for bits in &sregs.interrupt_bitmap {
-            if *bits != 0 {
-                return Err(libc::EINVAL.into());
-            }
-        }
         self.set_reg(&reg_assocs)?;
         Ok(())
     }
@@ -850,14 +847,6 @@ impl VcpuFd {
                 reg64: sregs.apic_base,
             },
         ];
-
-        // TODO support asserting an interrupt using interrupt_bitmap
-        // we can't do this without the vm fd which isn't available here
-        for bits in &sregs.interrupt_bitmap {
-            if *bits != 0 {
-                return Err(libc::EINVAL.into());
-            }
-        }
 
         let reg_assocs: Vec<hv_register_assoc> = reg_names
             .iter()

--- a/mshv-ioctls/src/ioctls/vcpu.rs
+++ b/mshv-ioctls/src/ioctls/vcpu.rs
@@ -1928,6 +1928,18 @@ mod tests {
 
     #[cfg(target_arch = "x86_64")]
     #[test]
+    fn test_set_sregs_interrupt_bitmap() {
+        let hv = Mshv::new().unwrap();
+        let vm = hv.create_vm().unwrap();
+        vm.initialize().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut sregs = vcpu.get_sregs().unwrap();
+        sregs.interrupt_bitmap[0] = 1;
+        vcpu.set_sregs(&sregs).unwrap();
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
     fn test_set_get_standard_registers() {
         let hv = Mshv::new().unwrap();
         let vm = hv.create_vm().unwrap();


### PR DESCRIPTION
### Summary of the PR

`get_sregs` populates `SpecialRegisters.interrupt_bitmap` from `HV_REGISTER_PENDING_INTERRUPTION` when a vCPU has a pending external interrupt, but `set_sregs` rejected any non zero `interrupt_bitmap` with `EINVAL`. A snapshot captured with a pending interrupt could therefore not be restored. The pending interrupt is already carried by `HV_REGISTER_PENDING_INTERRUPTION` and restored through `set_vcpu_events`, so the bitmap in `sregs` is redundant on the set path. Drop the check so `get_sregs` and `set_sregs` round trip.

### Requirements

- [x] All commits in this PR have Signed-Off-By trailers (with `git commit -s`), and the commit message has max 60 characters for the summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
